### PR TITLE
fix: use semver in all domainpack binding specs

### DIFF
--- a/domainpacks/bio_stub/binding_spec.yaml
+++ b/domainpacks/bio_stub/binding_spec.yaml
@@ -1,5 +1,5 @@
 name: bio_stub
-version: "0.1"
+version: "0.1.0"
 safety_tier: research
 sample_period_s: 0.001
 control_period_s: 0.01

--- a/domainpacks/geometry_walk/binding_spec.yaml
+++ b/domainpacks/geometry_walk/binding_spec.yaml
@@ -1,5 +1,5 @@
 name: geometry_walk
-version: "0.1"
+version: "0.1.0"
 safety_tier: research
 sample_period_s: 0.01
 control_period_s: 0.1

--- a/domainpacks/minimal_domain/binding_spec.yaml
+++ b/domainpacks/minimal_domain/binding_spec.yaml
@@ -1,5 +1,5 @@
 name: minimal_domain
-version: "0.1"
+version: "0.1.0"
 safety_tier: research
 sample_period_s: 0.01
 control_period_s: 0.1

--- a/domainpacks/queuewaves/binding_spec.yaml
+++ b/domainpacks/queuewaves/binding_spec.yaml
@@ -1,5 +1,5 @@
 name: queuewaves
-version: "0.1"
+version: "0.1.0"
 safety_tier: research
 sample_period_s: 0.01
 control_period_s: 0.1


### PR DESCRIPTION
## Summary
- Fix version field in all 4 domainpacks: `"0.1"` → `"0.1.0"` (semver)
- `spo run` was failing on every domainpack because the validator requires `major.minor.patch`

Found by running the reviewer-suggested smoke test:
```
$ spo run domainpacks/minimal_domain/binding_spec.yaml --steps 1000
ERROR: version must be major.minor.patch, got '0.1'
```

## Test plan
- [x] `spo validate` passes for all 4 domainpacks
- [x] `spo run --steps 1000` produces correct output for all 4
- [x] 216 tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)