### PR TITLE
Harden network and policy config surfaces

### DIFF
--- a/docs/guide/queuewaves.md
+++ b/docs/guide/queuewaves.md
@@ -69,6 +69,11 @@ alert_sinks:
 server:
   host: 0.0.0.0
   port: 8080
+
+security:
+  mode: production
+  api_key_env: QUEUEWAVES_API_KEY
+  rate_limit_per_minute: 120
 ```
 
 ### Key Fields
@@ -83,6 +88,9 @@ server:
 | `thresholds.plv_cascade` | 0.85 | PLV cascade propagation threshold |
 | `thresholds.imprint_chronic` | 1.5 | Imprint chronic degradation threshold |
 | `thresholds.cooldown_seconds` | 300.0 | Alert deduplication cooldown |
+| `security.mode` | development | `production` requires API key auth and rate limiting |
+| `security.api_key_env` | QUEUEWAVES_API_KEY | Environment variable containing the API key |
+| `security.rate_limit_per_minute` | 120 | Per-key request limit in production mode |
 
 ### ConfigCompiler
 
@@ -99,11 +107,14 @@ server:
 ### Continuous server
 
 ```bash
+export QUEUEWAVES_API_KEY="$(openssl rand -hex 32)"
 spo queuewaves serve --config queuewaves.yaml --host 0.0.0.0 --port 8080
 ```
 
 Starts a FastAPI application. Scrapes Prometheus on each interval, runs the
 UPDE pipeline, detects anomalies, fires alerts, and pushes state over WebSocket.
+When `security.mode: production` is set, REST and WebSocket clients must send
+`X-API-Key: <value of QUEUEWAVES_API_KEY>`.
 
 ### One-shot check
 
@@ -215,5 +226,6 @@ uvicorn scpn_phase_orchestrator.apps.queuewaves.server:create_app \
 ```
 
 QueueWaves is single-process (shared pipeline state). Run behind nginx or
-Traefik for TLS termination. For multiple clusters, run one QueueWaves
-instance per Prometheus source.
+Traefik for TLS termination, set `security.mode: production`, and provide
+`QUEUEWAVES_API_KEY` before binding to non-loopback interfaces. For multiple
+clusters, run one QueueWaves instance per Prometheus source.

--- a/src/scpn_phase_orchestrator/adapters/modbus_tls.py
+++ b/src/scpn_phase_orchestrator/adapters/modbus_tls.py
@@ -81,8 +81,8 @@ class SecureModbusAdapter:
                 ctx.check_hostname = False
                 ctx.verify_mode = ssl.CERT_NONE
             return ctx
-        except ssl.SSLError as exc:
-            raise ConnectionError(f"TLS context creation failed: {exc}") from exc
+        except ssl.SSLError:
+            raise ConnectionError("TLS context creation failed") from None
 
     def _connect(self) -> object:
         if ModbusTlsClient is None:
@@ -95,9 +95,7 @@ class SecureModbusAdapter:
             sslctx=self._ctx,
         )
         if not client.connect():
-            raise ConnectionError(
-                f"Modbus TLS connection failed: {self._host}:{self._port}"
-            )
+            raise ConnectionError("Modbus TLS connection failed")
         return client
 
     def read_register(self, address: int) -> int:

--- a/src/scpn_phase_orchestrator/adapters/prometheus.py
+++ b/src/scpn_phase_orchestrator/adapters/prometheus.py
@@ -38,8 +38,8 @@ class PrometheusAdapter:
         try:
             with urlopen(req, timeout=self._timeout) as resp:  # nosec B310
                 body = json.loads(resp.read())
-        except (URLError, OSError) as exc:
-            raise ConnectionError(f"Prometheus query failed: {exc}") from exc
+        except (URLError, OSError):
+            raise ConnectionError("Prometheus query failed") from None
 
         if body.get("status") != "success":
             raise ValueError(f"Prometheus returned status={body.get('status')}")
@@ -59,8 +59,8 @@ class PrometheusAdapter:
         try:
             with urlopen(req, timeout=self._timeout) as resp:  # nosec B310
                 body = json.loads(resp.read())
-        except (URLError, OSError) as exc:
-            raise ConnectionError(f"Prometheus query failed: {exc}") from exc
+        except (URLError, OSError):
+            raise ConnectionError("Prometheus query failed") from None
 
         if body.get("status") != "success":
             raise ValueError(f"Prometheus returned status={body.get('status')}")

--- a/src/scpn_phase_orchestrator/apps/queuewaves/alerter.py
+++ b/src/scpn_phase_orchestrator/apps/queuewaves/alerter.py
@@ -112,11 +112,7 @@ class WebhookAlerter:
                         resp = await client.post(sink.url, json=payload)
                         resp.raise_for_status()
                     except _SEND_ERRORS:
-                        logger.warning(
-                            "alert POST failed to %s",
-                            sink.url,
-                            exc_info=True,
-                        )
+                        logger.warning("alert POST failed for configured sink")
         return [a for a, _ in to_send]
 
     def send_sync(self, anomalies: list[Anomaly]) -> list[Anomaly]:

--- a/src/scpn_phase_orchestrator/apps/queuewaves/config.py
+++ b/src/scpn_phase_orchestrator/apps/queuewaves/config.py
@@ -9,7 +9,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from math import isfinite
 from pathlib import Path
+from urllib.parse import urlparse
 
 import yaml
 
@@ -28,11 +30,58 @@ __all__ = [
     "ServiceDef",
     "ThresholdConfig",
     "AlertSink",
+    "SecurityConfig",
     "QueueWavesConfig",
     "ConfigCompiler",
 ]
 
 _LAYER_ORDER = {"micro": 0, "meso": 1, "macro": 2}
+_VALID_CHANNELS = frozenset({"P", "I"})
+_VALID_ALERT_FORMATS = frozenset({"generic", "slack"})
+_VALID_SECURITY_MODES = frozenset({"development", "production"})
+
+
+def _require_non_empty(value: str, field_name: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{field_name} must be a non-empty string")
+    return value
+
+
+def _require_finite_non_negative(value: float, field_name: str) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field_name} must be finite and non-negative") from exc
+    if not isfinite(parsed) or parsed < 0.0:
+        raise ValueError(f"{field_name} must be finite and non-negative")
+    return parsed
+
+
+def _require_int_range(
+    value: int,
+    field_name: str,
+    minimum: int,
+    maximum: int | None = None,
+) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"{field_name} must be an integer")
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field_name} must be an integer") from exc
+    if parsed < minimum:
+        raise ValueError(f"{field_name} must be >= {minimum}")
+    if maximum is not None and parsed > maximum:
+        raise ValueError(f"{field_name} must be <= {maximum}")
+    return parsed
+
+
+def _require_http_url(value: str, field_name: str) -> str:
+    parsed_value = _require_non_empty(value, field_name)
+    parsed = urlparse(value)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        raise ValueError(f"{field_name} must be an http(s) URL")
+    return parsed_value
 
 
 @dataclass(frozen=True)
@@ -43,6 +92,16 @@ class ServiceDef:
     promql: str
     layer: str  # micro, meso, macro
     channel: str = "P"  # P(hysical) or I(nformational)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "name", _require_non_empty(self.name, "service.name"))
+        object.__setattr__(
+            self, "promql", _require_non_empty(self.promql, "service.promql")
+        )
+        if self.layer not in _LAYER_ORDER:
+            raise ValueError("service.layer must be micro, meso, or macro")
+        if self.channel not in _VALID_CHANNELS:
+            raise ValueError("service.channel must be P or I")
 
 
 @dataclass(frozen=True)
@@ -55,6 +114,41 @@ class ThresholdConfig:
     imprint_chronic: float = 1.5
     cooldown_seconds: float = 300.0
 
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "r_bad_warn",
+            _require_finite_non_negative(self.r_bad_warn, "thresholds.r_bad_warn"),
+        )
+        object.__setattr__(
+            self,
+            "r_bad_critical",
+            _require_finite_non_negative(
+                self.r_bad_critical, "thresholds.r_bad_critical"
+            ),
+        )
+        object.__setattr__(
+            self,
+            "plv_cascade",
+            _require_finite_non_negative(self.plv_cascade, "thresholds.plv_cascade"),
+        )
+        object.__setattr__(
+            self,
+            "imprint_chronic",
+            _require_finite_non_negative(
+                self.imprint_chronic, "thresholds.imprint_chronic"
+            ),
+        )
+        object.__setattr__(
+            self,
+            "cooldown_seconds",
+            _require_finite_non_negative(
+                self.cooldown_seconds, "thresholds.cooldown_seconds"
+            ),
+        )
+        if self.r_bad_warn > self.r_bad_critical:
+            raise ValueError("thresholds.r_bad_warn must be <= r_bad_critical")
+
 
 @dataclass(frozen=True)
 class CouplingConfig:
@@ -62,6 +156,16 @@ class CouplingConfig:
 
     strength: float = 0.50
     decay: float = 0.25
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "strength",
+            _require_finite_non_negative(self.strength, "coupling.strength"),
+        )
+        object.__setattr__(
+            self, "decay", _require_finite_non_negative(self.decay, "coupling.decay")
+        )
 
 
 @dataclass(frozen=True)
@@ -71,6 +175,13 @@ class AlertSink:
     url: str
     format: str = "generic"  # "slack" or "generic"
 
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "url", _require_http_url(self.url, "alert_sinks[].url")
+        )
+        if self.format not in _VALID_ALERT_FORMATS:
+            raise ValueError("alert_sinks[].format must be generic or slack")
+
 
 @dataclass(frozen=True)
 class ServerConfig:
@@ -78,6 +189,37 @@ class ServerConfig:
 
     host: str = "127.0.0.1"
     port: int = 8080
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "host", _require_non_empty(self.host, "server.host"))
+        object.__setattr__(
+            self, "port", _require_int_range(self.port, "server.port", 0, 65535)
+        )
+
+
+@dataclass(frozen=True)
+class SecurityConfig:
+    """QueueWaves production network security policy."""
+
+    mode: str = "development"
+    api_key_env: str = "QUEUEWAVES_API_KEY"
+    rate_limit_per_minute: int = 120
+
+    def __post_init__(self) -> None:
+        if self.mode not in _VALID_SECURITY_MODES:
+            raise ValueError("security.mode must be development or production")
+        object.__setattr__(
+            self,
+            "api_key_env",
+            _require_non_empty(self.api_key_env, "security.api_key_env"),
+        )
+        object.__setattr__(
+            self,
+            "rate_limit_per_minute",
+            _require_int_range(
+                self.rate_limit_per_minute, "security.rate_limit_per_minute", 1
+            ),
+        )
 
 
 @dataclass
@@ -92,6 +234,18 @@ class QueueWavesConfig:
     coupling: CouplingConfig = field(default_factory=CouplingConfig)
     alert_sinks: list[AlertSink] = field(default_factory=list)
     server: ServerConfig = field(default_factory=ServerConfig)
+    security: SecurityConfig = field(default_factory=SecurityConfig)
+
+    def __post_init__(self) -> None:
+        self.prometheus_url = _require_http_url(self.prometheus_url, "prometheus_url")
+        if not self.services:
+            raise ValueError("services must contain at least one service")
+        self.scrape_interval_s = _require_finite_non_negative(
+            self.scrape_interval_s, "scrape_interval_s"
+        )
+        if self.scrape_interval_s <= 0.0:
+            raise ValueError("scrape_interval_s must be > 0")
+        self.buffer_length = _require_int_range(self.buffer_length, "buffer_length", 4)
 
 
 def load_config(path: Path) -> QueueWavesConfig:
@@ -134,6 +288,12 @@ def load_config(path: Path) -> QueueWavesConfig:
         host=srv_raw.get("host", "127.0.0.1"),
         port=srv_raw.get("port", 8080),
     )
+    sec_raw = raw.get("security", {})
+    security_cfg = SecurityConfig(
+        mode=sec_raw.get("mode", "development"),
+        api_key_env=sec_raw.get("api_key_env", "QUEUEWAVES_API_KEY"),
+        rate_limit_per_minute=sec_raw.get("rate_limit_per_minute", 120),
+    )
     return QueueWavesConfig(
         prometheus_url=raw["prometheus_url"],
         services=services,
@@ -143,6 +303,7 @@ def load_config(path: Path) -> QueueWavesConfig:
         coupling=coupling_cfg,
         alert_sinks=sinks,
         server=server_cfg,
+        security=security_cfg,
     )
 
 

--- a/src/scpn_phase_orchestrator/apps/queuewaves/server.py
+++ b/src/scpn_phase_orchestrator/apps/queuewaves/server.py
@@ -10,6 +10,7 @@ import asyncio
 import contextlib
 import json
 import logging
+import os
 from collections import deque
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -29,6 +30,7 @@ from scpn_phase_orchestrator.apps.queuewaves.pipeline import (
     PhaseComputePipeline,
     PipelineSnapshot,
 )
+from scpn_phase_orchestrator.network_security import FixedWindowRateLimiter
 
 _IO_ERRORS: tuple[type[BaseException], ...] = (
     ConnectionError,
@@ -46,7 +48,15 @@ _MAX_HISTORY = 500
 
 def create_app(cfg: QueueWavesConfig) -> object:
     """Build a FastAPI application wired to the given config."""
-    from fastapi import FastAPI, WebSocket, WebSocketDisconnect  # noqa: F811
+    from fastapi import (
+        Depends,
+        FastAPI,
+        Header,
+        HTTPException,
+        Request,
+        WebSocket,
+        WebSocketDisconnect,
+    )
     from fastapi.responses import FileResponse, JSONResponse, PlainTextResponse
     from fastapi.staticfiles import StaticFiles
 
@@ -59,6 +69,31 @@ def create_app(cfg: QueueWavesConfig) -> object:
     history: deque[PipelineSnapshot] = deque(maxlen=_MAX_HISTORY)
     active_anomalies: list[Any] = []
     ws_clients: set[WebSocket] = set()
+    mode = cfg.security.mode.strip().lower()
+    if mode not in ("development", "production"):
+        raise ValueError("QueueWaves security.mode must be development or production")
+    api_key = os.environ.get(cfg.security.api_key_env)
+    if mode == "production" and not api_key:
+        raise RuntimeError(
+            f"{cfg.security.api_key_env} is required when QueueWaves runs in production"
+        )
+    rate_limit = cfg.security.rate_limit_per_minute if mode == "production" else 0
+    if rate_limit < 0:
+        raise ValueError("QueueWaves rate_limit_per_minute must be non-negative")
+    limiter = FixedWindowRateLimiter(rate_limit) if rate_limit > 0 else None
+
+    async def _require_network_access(
+        request: Request,
+        x_api_key: str | None = Header(None),
+    ) -> None:
+        if api_key is None:
+            identity = request.client.host if request.client is not None else "local"
+        elif x_api_key != api_key:
+            raise HTTPException(status_code=401, detail="Invalid or missing X-API-Key")
+        else:
+            identity = x_api_key
+        if limiter is not None and not limiter.allow(identity):
+            raise HTTPException(status_code=429, detail="Rate limit exceeded")
 
     async def _broadcast(msg: dict[str, Any]) -> None:  # pragma: no cover
         payload = json.dumps(msg)
@@ -139,25 +174,25 @@ def create_app(cfg: QueueWavesConfig) -> object:
 
     # --- REST endpoints ---
 
-    @app.get("/api/v1/health")
+    @app.get("/api/v1/health", dependencies=[Depends(_require_network_access)])
     async def health() -> dict[str, Any]:
         """Handle GET /api/v1/health — liveness check with tick counter."""
         return {"status": "ok", "tick": pipeline.tick_count}
 
-    @app.get("/api/v1/state")
+    @app.get("/api/v1/state", dependencies=[Depends(_require_network_access)])
     async def state() -> Any:
         """Handle GET /api/v1/state — return latest pipeline snapshot."""
         if not history:
             return JSONResponse({"error": "no data yet"}, status_code=503)
         return history[-1].to_dict()  # pragma: no cover — data branch, ASGI thread
 
-    @app.get("/api/v1/state/history")
+    @app.get("/api/v1/state/history", dependencies=[Depends(_require_network_access)])
     async def state_history(n: int = 100) -> list[dict[str, Any]]:
         """Handle GET /api/v1/state/history — return last n snapshots."""
         sliced = list(history)[-n:]
         return [s.to_dict() for s in sliced]
 
-    @app.get("/api/v1/anomalies")
+    @app.get("/api/v1/anomalies", dependencies=[Depends(_require_network_access)])
     async def anomalies() -> list[dict[str, Any]]:
         """Handle GET /api/v1/anomalies — return active anomaly list."""
         return [
@@ -172,7 +207,7 @@ def create_app(cfg: QueueWavesConfig) -> object:
             for a in active_anomalies
         ]
 
-    @app.get("/api/v1/services")
+    @app.get("/api/v1/services", dependencies=[Depends(_require_network_access)])
     async def services() -> list[dict[str, Any]]:
         """Handle GET /api/v1/services — return per-service phase state."""
         if not history:
@@ -189,14 +224,16 @@ def create_app(cfg: QueueWavesConfig) -> object:
             for s in snap.services
         ]
 
-    @app.get("/api/v1/plv")
+    @app.get("/api/v1/plv", dependencies=[Depends(_require_network_access)])
     async def plv() -> dict[str, Any]:
         """Handle GET /api/v1/plv — return cross-layer PLV matrix."""
         if not history:
             return {"matrix": []}
         return {"matrix": history[-1].plv_matrix}  # pragma: no cover
 
-    @app.get("/api/v1/metrics/prometheus")
+    @app.get(
+        "/api/v1/metrics/prometheus", dependencies=[Depends(_require_network_access)]
+    )
     async def prom_metrics() -> PlainTextResponse:
         """Handle GET /api/v1/metrics/prometheus — export Prometheus text metrics."""
         lines: list[str] = []
@@ -215,7 +252,7 @@ def create_app(cfg: QueueWavesConfig) -> object:
                 )
         return PlainTextResponse("\n".join(lines) + "\n", media_type="text/plain")
 
-    @app.post("/api/v1/check")
+    @app.post("/api/v1/check", dependencies=[Depends(_require_network_access)])
     async def check() -> Any:
         """One-shot: scrape, analyze, return result."""
         await collector.scrape()
@@ -248,6 +285,14 @@ def create_app(cfg: QueueWavesConfig) -> object:
     @app.websocket("/ws/stream")
     async def ws_stream(websocket: WebSocket) -> None:
         """Read-only observer stream. Incoming messages are ignored (keepalive only)."""
+        if api_key is not None and websocket.headers.get("x-api-key") != api_key:
+            await websocket.close(code=1008, reason="Invalid or missing X-API-Key")
+            return
+        if limiter is not None:
+            identity = websocket.headers.get("x-api-key") or "websocket"
+            if not limiter.allow(identity):
+                await websocket.close(code=1013, reason="Rate limit exceeded")
+                return
         await websocket.accept()
         ws_clients.add(websocket)
         try:

--- a/src/scpn_phase_orchestrator/network_security.py
+++ b/src/scpn_phase_orchestrator/network_security.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Commercial license available
+# © Concepts 1996–2026 Miroslav Šotek. All rights reserved.
+# © Code 2020–2026 Miroslav Šotek. All rights reserved.
+# ORCID: 0009-0009-3560-0851
+# Contact: www.anulum.li | protoscience@anulum.li
+# SCPN Phase Orchestrator — Network service security helpers
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+
+__all__ = ["FixedWindowRateLimiter", "env_int", "is_production_mode"]
+
+
+def is_production_mode(prefix: str) -> bool:
+    """Return True when a service-specific or generic env profile is production."""
+    for key in (f"{prefix}_ENV", f"{prefix}_PROFILE", "SPO_ENV", "SPO_PROFILE"):
+        if os.environ.get(key, "").strip().lower() == "production":
+            return True
+    return False
+
+
+def env_int(name: str, default: int) -> int:
+    """Read a non-negative integer from the environment."""
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be an integer") from exc
+    if value < 0:
+        raise ValueError(f"{name} must be non-negative")
+    return value
+
+
+class FixedWindowRateLimiter:
+    """Thread-safe per-identity fixed-window rate limiter."""
+
+    def __init__(self, limit_per_minute: int) -> None:
+        if limit_per_minute < 1:
+            raise ValueError("limit_per_minute must be >= 1")
+        self._limit = limit_per_minute
+        self._lock = threading.Lock()
+        self._windows: dict[str, tuple[int, int]] = {}
+
+    def allow(self, identity: str, now: float | None = None) -> bool:
+        """Return True if *identity* has capacity in the current minute."""
+        timestamp = time.time() if now is None else now
+        window = int(timestamp // 60)
+        key = identity or "anonymous"
+        with self._lock:
+            current_window, count = self._windows.get(key, (window, 0))
+            if current_window != window:
+                current_window, count = window, 0
+            if count >= self._limit:
+                self._windows[key] = (current_window, count)
+                return False
+            self._windows[key] = (current_window, count + 1)
+            return True

--- a/src/scpn_phase_orchestrator/server.py
+++ b/src/scpn_phase_orchestrator/server.py
@@ -12,11 +12,10 @@ Usage:
     spo serve binding_spec.yaml --port 8080
     # Then open http://localhost:8080 in a browser.
 
-    # With API key authentication:
-    SPO_API_KEY=mysecret spo serve binding_spec.yaml --port 8080
+    # Production profile requires API key authentication and rate limiting:
+    SPO_ENV=production SPO_API_KEY=<strong-api-key> spo serve binding_spec.yaml
     # Mutable endpoints (step, reset) require X-API-Key header.
-    # When SPO_API_KEY is unset, mutable endpoints are unrestricted
-    # (development mode — do NOT deploy without setting the key).
+    # Development mode remains local by default; do not deploy it externally.
 
 Endpoints:
     GET  /             HTML dashboard
@@ -59,7 +58,8 @@ from scpn_phase_orchestrator.upde.order_params import compute_order_parameter
 from scpn_phase_orchestrator.upde.stuart_landau import StuartLandauEngine
 
 try:
-    from fastapi import (  # pragma: no cover
+    from fastapi import Request as FastAPIRequest
+    from fastapi import (
         Response,
         WebSocket,
         WebSocketDisconnect,  # pragma: no cover
@@ -375,6 +375,12 @@ def create_app(spec_path: str | Path) -> object:  # pragma: no cover
         msg = "fastapi not installed. pip install fastapi uvicorn"
         raise ImportError(msg) from exc
 
+    from scpn_phase_orchestrator.network_security import (
+        FixedWindowRateLimiter,
+        env_int,
+        is_production_mode,
+    )
+
     spec = load_binding_spec(spec_path)
     sim = SimulationState(spec)
 
@@ -403,12 +409,24 @@ def create_app(spec_path: str | Path) -> object:  # pragma: no cover
     app = FastAPI(title="SPO Dashboard", version="0.5.0", lifespan=_lifespan)
 
     _api_key = os.environ.get("SPO_API_KEY")
+    _production = is_production_mode("SPO")
+    if _production and not _api_key:
+        raise RuntimeError("SPO_API_KEY is required when SPO_ENV=production")
+    _rate_limit = env_int("SPO_RATE_LIMIT_PER_MINUTE", 120 if _production else 0)
+    _limiter = FixedWindowRateLimiter(_rate_limit) if _rate_limit > 0 else None
 
-    async def _require_auth(x_api_key: str | None = Header(None)) -> None:
+    async def _require_auth(
+        request: FastAPIRequest,
+        x_api_key: str | None = Header(None),
+    ) -> None:
         if _api_key is None:
-            return
-        if x_api_key != _api_key:
+            identity = request.client.host if request.client is not None else "local"
+        elif x_api_key != _api_key:
             raise HTTPException(status_code=401, detail="Invalid or missing X-API-Key")
+        else:
+            identity = x_api_key
+        if _limiter is not None and not _limiter.allow(identity):
+            raise HTTPException(status_code=429, detail="Rate limit exceeded")
 
     @app.get("/", response_class=HTMLResponse)
     async def dashboard() -> str:

--- a/src/scpn_phase_orchestrator/server_grpc.py
+++ b/src/scpn_phase_orchestrator/server_grpc.py
@@ -19,6 +19,7 @@ with a mocked context.
 from __future__ import annotations
 
 import logging
+import os
 import time
 from collections.abc import Iterator
 from typing import Any
@@ -28,6 +29,11 @@ from scpn_phase_orchestrator.grpc_gen import (
     LayerState,
     PhaseOrchestratorServicer,
     StateResponse,
+)
+from scpn_phase_orchestrator.network_security import (
+    FixedWindowRateLimiter,
+    env_int,
+    is_production_mode,
 )
 from scpn_phase_orchestrator.server import SimulationState
 
@@ -77,16 +83,48 @@ class PhaseStreamServicer(PhaseOrchestratorServicer):
         # handlers serialise against the same lock. A servicer-local lock
         # would leave the HTTP side free to race on shared engine state.
         self._lock = sim._lock
+        self._api_key = os.environ.get("SPO_GRPC_API_KEY") or os.environ.get(
+            "SPO_API_KEY"
+        )
+        self._production = is_production_mode("SPO_GRPC") or is_production_mode("SPO")
+        if self._production and not self._api_key:
+            raise RuntimeError(
+                "SPO_GRPC_API_KEY or SPO_API_KEY is required in production"
+            )
+        rate_limit = env_int(
+            "SPO_GRPC_RATE_LIMIT_PER_MINUTE", 120 if self._production else 0
+        )
+        self._limiter = FixedWindowRateLimiter(rate_limit) if rate_limit > 0 else None
+
+    def _abort(self, context: Any, code: Any, detail: str) -> None:
+        if context is not None and hasattr(context, "abort"):
+            context.abort(code, detail)
+        raise PermissionError(detail)
+
+    def _authorise(self, context: Any) -> None:
+        metadata = {}
+        if context is not None and hasattr(context, "invocation_metadata"):
+            metadata = dict(context.invocation_metadata())
+        supplied = metadata.get("x-api-key")
+        if self._api_key is not None and supplied != self._api_key:
+            code = grpc.StatusCode.UNAUTHENTICATED if grpc is not None else None
+            self._abort(context, code, "Invalid or missing x-api-key")
+        identity = supplied or "anonymous"
+        if self._limiter is not None and not self._limiter.allow(identity):
+            code = grpc.StatusCode.RESOURCE_EXHAUSTED if grpc is not None else None
+            self._abort(context, code, "Rate limit exceeded")
 
     # -- unary RPCs -----------------------------------------------------------
 
     def GetState(self, request: Any, context: Any) -> StateResponse:
         """gRPC unary RPC: return current simulation state."""
+        self._authorise(context)
         with self._lock:
             return _snap_to_response(self._sim.snapshot())
 
     def Step(self, request: Any, context: Any) -> StateResponse:
         """gRPC unary RPC: advance simulation by n_steps and return state."""
+        self._authorise(context)
         n = getattr(request, "n_steps", 1) or 1
         with self._lock:
             for _ in range(n):
@@ -103,6 +141,7 @@ class PhaseStreamServicer(PhaseOrchestratorServicer):
 
     def Reset(self, request: Any, context: Any) -> StateResponse:
         """gRPC unary RPC: reset simulation and return fresh state."""
+        self._authorise(context)
         with self._lock:
             self._sim.reset()
             response = _snap_to_response(self._sim.snapshot())
@@ -111,6 +150,7 @@ class PhaseStreamServicer(PhaseOrchestratorServicer):
 
     def GetConfig(self, request: Any, context: Any) -> ConfigResponse:
         """gRPC unary RPC: return engine configuration."""
+        self._authorise(context)
         spec = self._sim.spec
         return ConfigResponse(
             name=spec.name,
@@ -125,6 +165,7 @@ class PhaseStreamServicer(PhaseOrchestratorServicer):
 
     def StreamPhases(self, request: Any, context: Any) -> Iterator[StateResponse]:
         """Read-only observer: streams snapshots without advancing simulation."""
+        self._authorise(context)
         max_steps = getattr(request, "max_steps", 100) or 100
         interval = getattr(request, "interval_s", 0.05) or 0.05
         for _ in range(max_steps):

--- a/src/scpn_phase_orchestrator/supervisor/policy_rules.py
+++ b/src/scpn_phase_orchestrator/supervisor/policy_rules.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 
 import operator
 from dataclasses import dataclass
+from math import isfinite
 from pathlib import Path
+from typing import Any, NoReturn
 
 from scpn_phase_orchestrator.actuation.mapper import ControlAction
 from scpn_phase_orchestrator.supervisor.regimes import Regime
@@ -32,6 +34,10 @@ _OPS = {
     "<=": operator.le,
     "==": operator.eq,
 }
+
+_MAX_POLICY_RULES = 1000
+_MAX_CONDITIONS_PER_RULE = 32
+_MAX_ACTIONS_PER_RULE = 32
 
 
 @dataclass(frozen=True)
@@ -211,21 +217,94 @@ def _extract_metric(
     return None
 
 
-def _parse_condition(raw: dict) -> PolicyCondition:
+def _policy_error(message: str) -> NoReturn:
+    raise ValueError(f"invalid policy rules: {message}")
+
+
+def _require_mapping(raw: Any, context: str) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        _policy_error(f"{context} must be a mapping")
+    return raw
+
+
+def _require_field(raw: dict[str, Any], key: str, context: str) -> Any:
+    try:
+        return raw[key]
+    except KeyError:
+        _policy_error(f"{context} missing required key {key!r}")
+
+
+def _require_text(raw: dict[str, Any], key: str, context: str) -> str:
+    value = _require_field(raw, key, context)
+    if not isinstance(value, str) or not value:
+        _policy_error(f"{context}.{key} must be a non-empty string")
+    return value
+
+
+def _finite_float(value: Any, context: str) -> float:
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        _policy_error(f"{context} must be a finite number")
+    if not isfinite(result):
+        _policy_error(f"{context} must be a finite number")
+    return result
+
+
+def _non_negative_float(value: Any, context: str) -> float:
+    result = _finite_float(value, context)
+    if result < 0.0:
+        _policy_error(f"{context} must be non-negative")
+    return result
+
+
+def _non_negative_int(value: Any, context: str) -> int:
+    if isinstance(value, bool):
+        _policy_error(f"{context} must be a non-negative integer")
+    try:
+        result = int(value)
+    except (TypeError, ValueError):
+        _policy_error(f"{context} must be a non-negative integer")
+    if result < 0:
+        _policy_error(f"{context} must be non-negative")
+    return result
+
+
+def _require_sequence(value: Any, context: str) -> list[Any]:
+    if not isinstance(value, list):
+        _policy_error(f"{context} must be a list")
+    return value
+
+
+def _parse_condition(raw: Any) -> PolicyCondition:
+    data = _require_mapping(raw, "condition")
+    op = _require_text(data, "op", "condition")
+    if op not in _OPS:
+        _policy_error("condition.op is unsupported")
+    layer_raw = data.get("layer")
+    if layer_raw is not None:
+        layer = _non_negative_int(layer_raw, "condition.layer")
+    else:
+        layer = None
     return PolicyCondition(
-        metric=raw["metric"],
-        layer=raw.get("layer"),
-        op=raw["op"],
-        threshold=float(raw["threshold"]),
+        metric=_require_text(data, "metric", "condition"),
+        layer=layer,
+        op=op,
+        threshold=_finite_float(
+            _require_field(data, "threshold", "condition"), "condition.threshold"
+        ),
     )
 
 
-def _parse_action(raw: dict) -> PolicyAction:
+def _parse_action(raw: Any) -> PolicyAction:
+    data = _require_mapping(raw, "action")
     return PolicyAction(
-        knob=raw["knob"],
-        scope=raw["scope"],
-        value=float(raw["value"]),
-        ttl_s=float(raw["ttl_s"]),
+        knob=_require_text(data, "knob", "action"),
+        scope=_require_text(data, "scope", "action"),
+        value=_finite_float(_require_field(data, "value", "action"), "action.value"),
+        ttl_s=_non_negative_float(
+            _require_field(data, "ttl_s", "action"), "action.ttl_s"
+        ),
     )
 
 
@@ -238,35 +317,70 @@ def load_policy_rules(path: str | Path) -> list[PolicyRule]:
     import yaml
 
     path = Path(path)
-    raw = path.read_text(encoding="utf-8")
-    data = yaml.safe_load(raw)
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        reason = exc.strerror or type(exc).__name__
+        raise ValueError(f"cannot read policy rules: {reason}") from None
+    try:
+        data = yaml.safe_load(raw)
+    except yaml.YAMLError:
+        raise ValueError("policy rules YAML parse error") from None
     if not isinstance(data, dict) or "rules" not in data:
         return []
+    rule_data = _require_sequence(data["rules"], "rules")
+    if len(rule_data) > _MAX_POLICY_RULES:
+        _policy_error("too many rules")
     rules: list[PolicyRule] = []
-    for r in data["rules"]:
+    for raw_rule in rule_data:
+        r = _require_mapping(raw_rule, "rule")
         # --- condition(s) ---
         if "conditions" in r:
+            conditions = _require_sequence(r["conditions"], "rule.conditions")
+            if not conditions:
+                _policy_error("rule.conditions must not be empty")
+            if len(conditions) > _MAX_CONDITIONS_PER_RULE:
+                _policy_error("too many rule conditions")
+            logic = r.get("logic", "AND")
+            if not isinstance(logic, str):
+                _policy_error("rule.logic must be a string")
+            logic = logic.upper()
+            if logic not in ("AND", "OR"):
+                _policy_error("rule.logic must be AND or OR")
             cond: PolicyCondition | CompoundCondition = CompoundCondition(
-                conditions=[_parse_condition(c) for c in r["conditions"]],
-                logic=r.get("logic", "AND").upper(),
+                conditions=[_parse_condition(c) for c in conditions],
+                logic=logic,
             )
         else:
-            cond = _parse_condition(r["condition"])
+            cond = _parse_condition(_require_field(r, "condition", "rule"))
 
         # --- action(s) ---
         if "actions" in r:
-            action_list = [_parse_action(a) for a in r["actions"]]
+            actions = _require_sequence(r["actions"], "rule.actions")
+            if not actions:
+                _policy_error("rule.actions must not be empty")
+            if len(actions) > _MAX_ACTIONS_PER_RULE:
+                _policy_error("too many rule actions")
+            action_list = [_parse_action(a) for a in actions]
         else:
-            action_list = [_parse_action(r["action"])]
+            action_list = [_parse_action(_require_field(r, "action", "rule"))]
+
+        regimes = r.get("regime", [])
+        if not isinstance(regimes, list) or not all(
+            isinstance(item, str) and item for item in regimes
+        ):
+            _policy_error("rule.regime must be a list of non-empty strings")
 
         rules.append(
             PolicyRule(
-                name=r["name"],
-                regimes=[s.upper() for s in r.get("regime", [])],
+                name=_require_text(r, "name", "rule"),
+                regimes=[s.upper() for s in regimes],
                 condition=cond,
                 actions=action_list,
-                cooldown_s=float(r.get("cooldown_s", 0.0)),
-                max_fires=int(r.get("max_fires", 0)),
+                cooldown_s=_non_negative_float(
+                    r.get("cooldown_s", 0.0), "rule.cooldown_s"
+                ),
+                max_fires=_non_negative_int(r.get("max_fires", 0), "rule.max_fires"),
             )
         )
     return rules

--- a/tests/apps/queuewaves/test_alerter_coverage.py
+++ b/tests/apps/queuewaves/test_alerter_coverage.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 
 import asyncio
 import importlib.util
+import sys
+from types import SimpleNamespace
 
 import pytest
 
@@ -74,6 +76,44 @@ def test_async_send_with_sink_post_failure():
         alerter = WebhookAlerter([sink], cooldown_seconds=0.0)
         sent = await alerter.send([_anomaly()])
         assert len(sent) == 1
+
+    asyncio.run(_run())
+
+
+def test_async_send_failure_log_does_not_leak_sink_url(caplog, monkeypatch):
+    """Webhook failures must not echo sink URLs or HTTP exception details."""
+
+    class _FailingClient:
+        def __init__(self, timeout):
+            self.timeout = timeout
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def post(self, url, json):
+            raise OSError(f"ConnectError {url} PRIVATE_TOPOLOGY")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "httpx",
+        SimpleNamespace(AsyncClient=_FailingClient),
+    )
+
+    async def _run():
+        sink_url = "http://ops.internal.example:8080/hook?tenant=PRIVATE_TOPOLOGY"
+        sink = AlertSink(url=sink_url, format="generic")
+        alerter = WebhookAlerter([sink], cooldown_seconds=0.0)
+        with caplog.at_level("WARNING"):
+            sent = await alerter.send([_anomaly()])
+        assert len(sent) == 1
+        text = caplog.text
+        assert "alert POST failed for configured sink" in text
+        assert "ops.internal.example" not in text
+        assert "PRIVATE_TOPOLOGY" not in text
+        assert "ConnectError" not in text
 
     asyncio.run(_run())
 

--- a/tests/apps/queuewaves/test_config.py
+++ b/tests/apps/queuewaves/test_config.py
@@ -9,11 +9,20 @@
 from __future__ import annotations
 
 import textwrap
+from collections.abc import Callable
 from pathlib import Path
 
+import pytest
+
 from scpn_phase_orchestrator.apps.queuewaves.config import (
+    AlertSink,
     ConfigCompiler,
+    CouplingConfig,
     QueueWavesConfig,
+    SecurityConfig,
+    ServerConfig,
+    ServiceDef,
+    ThresholdConfig,
     load_config,
 )
 
@@ -42,6 +51,10 @@ def test_load_config(tmp_path: Path) -> None:
             format: slack
         server:
           port: 9999
+        security:
+          mode: production
+          api_key_env: QUEUEWAVES_API_KEY
+          rate_limit_per_minute: 240
     """)
     f = tmp_path / "qw.yaml"
     f.write_text(yaml_text, encoding="utf-8")
@@ -53,6 +66,9 @@ def test_load_config(tmp_path: Path) -> None:
     assert cfg.coupling.strength == 0.40
     assert len(cfg.alert_sinks) == 1
     assert cfg.server.port == 9999
+    assert cfg.security.mode == "production"
+    assert cfg.security.api_key_env == "QUEUEWAVES_API_KEY"
+    assert cfg.security.rate_limit_per_minute == 240
 
 
 def test_config_compiler_layers(minimal_config: QueueWavesConfig) -> None:
@@ -102,3 +118,147 @@ def test_load_config_defaults(tmp_path: Path) -> None:
     assert cfg.scrape_interval_s == 15.0
     assert cfg.buffer_length == 64
     assert cfg.thresholds.r_bad_warn == 0.50
+    assert cfg.security.mode == "development"
+    assert cfg.security.rate_limit_per_minute == 120
+
+
+def test_load_config_normalises_numeric_scalars(tmp_path: Path) -> None:
+    yaml_text = textwrap.dedent("""\
+        prometheus_url: "http://prom:9090"
+        scrape_interval_s: "2.5"
+        buffer_length: "8"
+        services:
+          - name: s1
+            promql: up
+        thresholds:
+          r_bad_warn: "0.1"
+          r_bad_critical: "0.2"
+        server:
+          port: "9091"
+        security:
+          rate_limit_per_minute: "30"
+    """)
+    f = tmp_path / "qw.yaml"
+    f.write_text(yaml_text, encoding="utf-8")
+
+    cfg = load_config(f)
+
+    assert cfg.scrape_interval_s == 2.5
+    assert cfg.buffer_length == 8
+    assert cfg.thresholds.r_bad_warn == 0.1
+    assert cfg.thresholds.r_bad_critical == 0.2
+    assert cfg.server.port == 9091
+    assert cfg.security.rate_limit_per_minute == 30
+    assert isinstance(cfg.scrape_interval_s, float)
+    assert isinstance(cfg.buffer_length, int)
+    assert isinstance(cfg.server.port, int)
+    assert isinstance(cfg.security.rate_limit_per_minute, int)
+
+
+@pytest.mark.parametrize(
+    ("yaml_text", "pattern"),
+    [
+        (
+            """\
+            prometheus_url: "file:///tmp/prom"
+            services:
+              - name: s1
+                promql: up
+            """,
+            "prometheus_url",
+        ),
+        (
+            """\
+            prometheus_url: "http://prom:9090"
+            services: []
+            """,
+            "services",
+        ),
+        (
+            """\
+            prometheus_url: "http://prom:9090"
+            services:
+              - name: ""
+                promql: up
+            """,
+            "service.name",
+        ),
+        (
+            """\
+            prometheus_url: "http://prom:9090"
+            services:
+              - name: s1
+                promql: up
+                layer: unknown
+            """,
+            "service.layer",
+        ),
+        (
+            """\
+            prometheus_url: "http://prom:9090"
+            services:
+              - name: s1
+                promql: up
+                channel: X
+            """,
+            "service.channel",
+        ),
+        (
+            """\
+            prometheus_url: "http://prom:9090"
+            services:
+              - name: s1
+                promql: up
+            scrape_interval_s: 0
+            """,
+            "scrape_interval_s",
+        ),
+        (
+            """\
+            prometheus_url: "http://prom:9090"
+            services:
+              - name: s1
+                promql: up
+            buffer_length: 3
+            """,
+            "buffer_length",
+        ),
+        (
+            """\
+            prometheus_url: "http://prom:9090"
+            services:
+              - name: s1
+                promql: up
+            security:
+              mode: exposed
+            """,
+            "security.mode",
+        ),
+    ],
+)
+def test_load_config_rejects_invalid_values(
+    tmp_path: Path, yaml_text: str, pattern: str
+) -> None:
+    path = tmp_path / "qw.yaml"
+    path.write_text(textwrap.dedent(yaml_text), encoding="utf-8")
+
+    with pytest.raises(ValueError, match=pattern):
+        load_config(path)
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda: ServiceDef(name="svc", promql="up", layer="micro", channel="S"),
+        lambda: ThresholdConfig(r_bad_warn=2.0, r_bad_critical=1.0),
+        lambda: CouplingConfig(strength=-0.1),
+        lambda: AlertSink(url="ftp://example.com/hook"),
+        lambda: AlertSink(url="https://example.com/hook", format="pager"),
+        lambda: ServerConfig(host="", port=8080),
+        lambda: ServerConfig(host="127.0.0.1", port=70000),
+        lambda: SecurityConfig(mode="production", rate_limit_per_minute=0),
+    ],
+)
+def test_direct_config_constructors_validate(factory: Callable[[], object]) -> None:
+    with pytest.raises(ValueError):
+        factory()

--- a/tests/apps/queuewaves/test_server.py
+++ b/tests/apps/queuewaves/test_server.py
@@ -10,7 +10,10 @@ from __future__ import annotations
 
 import pytest
 
-from scpn_phase_orchestrator.apps.queuewaves.config import QueueWavesConfig
+from scpn_phase_orchestrator.apps.queuewaves.config import (
+    QueueWavesConfig,
+    SecurityConfig,
+)
 
 pytest.importorskip("fastapi")
 pytest.importorskip("httpx")
@@ -75,3 +78,75 @@ def test_state_history_empty(client: TestClient) -> None:
     r = client.get("/api/v1/state/history?n=10")
     assert r.status_code == 200
     assert r.json() == []
+
+
+def test_production_requires_api_key_env(
+    minimal_config: QueueWavesConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cfg = QueueWavesConfig(
+        prometheus_url=minimal_config.prometheus_url,
+        services=minimal_config.services,
+        scrape_interval_s=minimal_config.scrape_interval_s,
+        buffer_length=minimal_config.buffer_length,
+        thresholds=minimal_config.thresholds,
+        coupling=minimal_config.coupling,
+        alert_sinks=minimal_config.alert_sinks,
+        server=minimal_config.server,
+        security=SecurityConfig(mode="production"),
+    )
+    monkeypatch.delenv("QUEUEWAVES_API_KEY", raising=False)
+
+    with pytest.raises(RuntimeError, match="QUEUEWAVES_API_KEY"):
+        create_app(cfg)
+
+
+def test_production_requires_request_api_key(
+    minimal_config: QueueWavesConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cfg = QueueWavesConfig(
+        prometheus_url=minimal_config.prometheus_url,
+        services=minimal_config.services,
+        scrape_interval_s=minimal_config.scrape_interval_s,
+        buffer_length=minimal_config.buffer_length,
+        thresholds=minimal_config.thresholds,
+        coupling=minimal_config.coupling,
+        alert_sinks=minimal_config.alert_sinks,
+        server=minimal_config.server,
+        security=SecurityConfig(mode="production"),
+    )
+    monkeypatch.setenv("QUEUEWAVES_API_KEY", "test-key")
+    client = TestClient(create_app(cfg))
+
+    missing = client.get("/api/v1/health")
+    present = client.get("/api/v1/health", headers={"X-API-Key": "test-key"})
+
+    assert missing.status_code == 401
+    assert present.status_code == 200
+
+
+def test_production_rate_limits_requests(
+    minimal_config: QueueWavesConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cfg = QueueWavesConfig(
+        prometheus_url=minimal_config.prometheus_url,
+        services=minimal_config.services,
+        scrape_interval_s=minimal_config.scrape_interval_s,
+        buffer_length=minimal_config.buffer_length,
+        thresholds=minimal_config.thresholds,
+        coupling=minimal_config.coupling,
+        alert_sinks=minimal_config.alert_sinks,
+        server=minimal_config.server,
+        security=SecurityConfig(mode="production", rate_limit_per_minute=1),
+    )
+    monkeypatch.setenv("QUEUEWAVES_API_KEY", "test-key")
+    client = TestClient(create_app(cfg))
+    headers = {"X-API-Key": "test-key"}
+
+    first = client.get("/api/v1/health", headers=headers)
+    second = client.get("/api/v1/health", headers=headers)
+
+    assert first.status_code == 200
+    assert second.status_code == 429

--- a/tests/test_adapters_coverage.py
+++ b/tests/test_adapters_coverage.py
@@ -157,6 +157,52 @@ class TestPrometheusAdapter:
         ):
             adapter.fetch_metric("up", 0, 10, 1)
 
+    def test_fetch_metric_network_error_does_not_leak_endpoint_or_query(self):
+        from urllib.error import URLError
+
+        from scpn_phase_orchestrator.adapters.prometheus import PrometheusAdapter
+
+        adapter = PrometheusAdapter("http://metrics.internal:9090/private")
+        with (
+            patch(
+                "scpn_phase_orchestrator.adapters.prometheus.urlopen",
+                side_effect=URLError(
+                    "http://metrics.internal:9090/private/api/v1/query_range"
+                    "?query=tenant_secret"
+                ),
+            ),
+            pytest.raises(ConnectionError) as excinfo,
+        ):
+            adapter.fetch_metric("tenant_secret", 0, 10, 1)
+        msg = str(excinfo.value)
+        assert msg == "Prometheus query failed"
+        assert "metrics.internal" not in msg
+        assert "tenant_secret" not in msg
+        assert excinfo.value.__cause__ is None
+
+    def test_fetch_instant_network_error_does_not_leak_endpoint_or_query(self):
+        from urllib.error import URLError
+
+        from scpn_phase_orchestrator.adapters.prometheus import PrometheusAdapter
+
+        adapter = PrometheusAdapter("http://metrics.internal:9090/private")
+        with (
+            patch(
+                "scpn_phase_orchestrator.adapters.prometheus.urlopen",
+                side_effect=URLError(
+                    "http://metrics.internal:9090/private/api/v1/query"
+                    "?query=tenant_secret"
+                ),
+            ),
+            pytest.raises(ConnectionError) as excinfo,
+        ):
+            adapter.fetch_instant("tenant_secret")
+        msg = str(excinfo.value)
+        assert msg == "Prometheus query failed"
+        assert "metrics.internal" not in msg
+        assert "tenant_secret" not in msg
+        assert excinfo.value.__cause__ is None
+
     def test_fetch_metric_bad_json(self):
         from scpn_phase_orchestrator.adapters.prometheus import PrometheusAdapter
 

--- a/tests/test_coverage_final.py
+++ b/tests/test_coverage_final.py
@@ -234,7 +234,7 @@ class TestQueueWavesConfigFormat:
 
         cfg = {
             "prometheus_url": "http://localhost:9090",
-            "services": [],
+            "services": [{"name": "svc", "promql": "up", "layer": "micro"}],
             "alert_sinks": [
                 {"url": "https://hooks.slack.com/test", "format": "slack"},
             ],
@@ -252,7 +252,7 @@ class TestQueueWavesConfigFormat:
 
         cfg = {
             "prometheus_url": "http://localhost:9090",
-            "services": [],
+            "services": [{"name": "svc", "promql": "up", "layer": "micro"}],
             "alert_sinks": [
                 {"url": "https://example.com/webhook"},
             ],

--- a/tests/test_modbus_tls.py
+++ b/tests/test_modbus_tls.py
@@ -192,6 +192,63 @@ class TestSecureModbusAdapterTLS:
             with pytest.raises(ConnectionError, match="connection failed"):
                 SecureModbusAdapter("localhost", 802, cert, key)
 
+    def test_connection_failure_does_not_leak_endpoint(self, tmp_path):
+        cert = tmp_path / "client.pem"
+        key = tmp_path / "client.key"
+        cert.write_text("dummy-cert")
+        key.write_text("dummy-key")
+
+        mock_client = MagicMock()
+        mock_client.connect.return_value = False
+
+        with (
+            patch(
+                "scpn_phase_orchestrator.adapters.modbus_tls.ModbusTlsClient",
+                return_value=mock_client,
+            ),
+            patch("scpn_phase_orchestrator.adapters.modbus_tls.ssl") as mock_ssl,
+        ):
+            mock_ctx = MagicMock()
+            mock_ssl.SSLContext.return_value = mock_ctx
+            mock_ssl.PROTOCOL_TLS_CLIENT = 2
+            mock_ssl.SSLError = Exception
+
+            from scpn_phase_orchestrator.adapters.modbus_tls import SecureModbusAdapter
+
+            with pytest.raises(ConnectionError) as excinfo:
+                SecureModbusAdapter("plc.internal.example", 802, cert, key)
+            msg = str(excinfo.value)
+            assert "connection failed" in msg
+            assert "plc.internal.example" not in msg
+            assert "802" not in msg
+
+    def test_tls_context_error_does_not_leak_backend_detail(self, tmp_path):
+        cert = tmp_path / "secret" / "client.pem"
+        key = tmp_path / "secret" / "client.key"
+        cert.parent.mkdir()
+        cert.write_text("dummy-cert")
+        key.write_text("dummy-key")
+
+        with patch("scpn_phase_orchestrator.adapters.modbus_tls.ssl") as mock_ssl:
+            mock_ctx = MagicMock()
+            mock_ctx.load_cert_chain.side_effect = Exception(
+                f"bad certificate path {cert} key {key}"
+            )
+            mock_ssl.SSLContext.return_value = mock_ctx
+            mock_ssl.PROTOCOL_TLS_CLIENT = 2
+            mock_ssl.SSLError = Exception
+
+            from scpn_phase_orchestrator.adapters.modbus_tls import SecureModbusAdapter
+
+            with pytest.raises(ConnectionError) as excinfo:
+                SecureModbusAdapter("localhost", 802, cert, key)
+            msg = str(excinfo.value)
+            assert msg == "TLS context creation failed"
+            assert "secret" not in msg
+            assert "client.pem" not in msg
+            assert "client.key" not in msg
+            assert str(tmp_path) not in msg
+
     def test_missing_cert_error_does_not_leak_full_path(self, tmp_path):
         from scpn_phase_orchestrator.adapters.modbus_tls import SecureModbusAdapter
 

--- a/tests/test_network_security.py
+++ b/tests/test_network_security.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Commercial license available
+# © Concepts 1996–2026 Miroslav Šotek. All rights reserved.
+# © Code 2020–2026 Miroslav Šotek. All rights reserved.
+# ORCID: 0009-0009-3560-0851
+# Contact: www.anulum.li | protoscience@anulum.li
+# SCPN Phase Orchestrator — Network security helper tests
+
+from __future__ import annotations
+
+import pytest
+
+from scpn_phase_orchestrator.network_security import (
+    FixedWindowRateLimiter,
+    env_int,
+    is_production_mode,
+)
+
+
+def test_is_production_mode_uses_service_specific_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("QUEUEWAVES_ENV", "production")
+    monkeypatch.setenv("SPO_ENV", "development")
+
+    assert is_production_mode("QUEUEWAVES") is True
+
+
+def test_is_production_mode_uses_generic_spo_profile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("SPO_GRPC_ENV", raising=False)
+    monkeypatch.setenv("SPO_PROFILE", "production")
+
+    assert is_production_mode("SPO_GRPC") is True
+
+
+def test_is_production_mode_ignores_non_production_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SPO_ENV", "development")
+    monkeypatch.setenv("SPO_PROFILE", "local")
+
+    assert is_production_mode("SPO") is False
+
+
+def test_env_int_default_and_valid_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SPO_RATE_LIMIT_PER_MINUTE", raising=False)
+    assert env_int("SPO_RATE_LIMIT_PER_MINUTE", 120) == 120
+
+    monkeypatch.setenv("SPO_RATE_LIMIT_PER_MINUTE", "7")
+    assert env_int("SPO_RATE_LIMIT_PER_MINUTE", 120) == 7
+
+
+def test_env_int_rejects_invalid_values(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SPO_RATE_LIMIT_PER_MINUTE", "not-an-int")
+    with pytest.raises(ValueError, match="must be an integer"):
+        env_int("SPO_RATE_LIMIT_PER_MINUTE", 120)
+
+    monkeypatch.setenv("SPO_RATE_LIMIT_PER_MINUTE", "-1")
+    with pytest.raises(ValueError, match="non-negative"):
+        env_int("SPO_RATE_LIMIT_PER_MINUTE", 120)
+
+
+def test_rate_limiter_allows_until_limit_then_blocks() -> None:
+    limiter = FixedWindowRateLimiter(limit_per_minute=2)
+
+    assert limiter.allow("client-a", now=10.0) is True
+    assert limiter.allow("client-a", now=11.0) is True
+    assert limiter.allow("client-a", now=12.0) is False
+
+
+def test_rate_limiter_is_per_identity() -> None:
+    limiter = FixedWindowRateLimiter(limit_per_minute=1)
+
+    assert limiter.allow("client-a", now=10.0) is True
+    assert limiter.allow("client-a", now=11.0) is False
+    assert limiter.allow("client-b", now=11.0) is True
+
+
+def test_rate_limiter_resets_on_new_window() -> None:
+    limiter = FixedWindowRateLimiter(limit_per_minute=1)
+
+    assert limiter.allow("client-a", now=59.0) is True
+    assert limiter.allow("client-a", now=59.5) is False
+    assert limiter.allow("client-a", now=60.0) is True
+
+
+def test_rate_limiter_rejects_non_positive_limit() -> None:
+    with pytest.raises(ValueError, match=">= 1"):
+        FixedWindowRateLimiter(limit_per_minute=0)

--- a/tests/test_policy_binding_fuzz.py
+++ b/tests/test_policy_binding_fuzz.py
@@ -1,0 +1,252 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Commercial license available
+# © Concepts 1996–2026 Miroslav Šotek. All rights reserved.
+# © Code 2020–2026 Miroslav Šotek. All rights reserved.
+# ORCID: 0009-0009-3560-0851
+# Contact: www.anulum.li | protoscience@anulum.li
+# SCPN Phase Orchestrator — Binding and policy fuzz tests
+
+from __future__ import annotations
+
+import json
+from math import isfinite
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import yaml
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from scpn_phase_orchestrator.binding import validate_binding_spec
+from scpn_phase_orchestrator.binding.loader import load_binding_spec
+from scpn_phase_orchestrator.supervisor.policy_rules import (
+    PolicyEngine,
+    load_policy_rules,
+)
+from scpn_phase_orchestrator.supervisor.regimes import Regime
+from scpn_phase_orchestrator.upde.metrics import LayerState, UPDEState
+
+_SAFE_TEXT = st.text(
+    alphabet=st.characters(
+        whitelist_categories=("Ll", "Lu", "Nd"),
+        whitelist_characters=("_", "-"),
+    ),
+    min_size=1,
+    max_size=24,
+)
+
+
+def _valid_binding_data(
+    name: str,
+    layer_count: int,
+    sample_period_s: float,
+    control_multiplier: int,
+    base_strength: float,
+    decay_alpha: float,
+) -> dict[str, Any]:
+    layers = [
+        {
+            "name": f"L{idx}",
+            "index": idx,
+            "oscillator_ids": [f"osc_{idx}"],
+            "omegas": [1.0 + 0.1 * idx],
+        }
+        for idx in range(layer_count)
+    ]
+    return {
+        "name": name,
+        "version": "0.2.0",
+        "safety_tier": "research",
+        "sample_period_s": sample_period_s,
+        "control_period_s": sample_period_s * control_multiplier,
+        "layers": layers,
+        "oscillator_families": {
+            "physical": {"channel": "P", "extractor_type": "hilbert", "config": {}}
+        },
+        "coupling": {"base_strength": base_strength, "decay_alpha": decay_alpha},
+        "drivers": {"physical": {}, "informational": {}, "symbolic": {}},
+        "objectives": {"good_layers": [0], "bad_layers": []},
+        "boundaries": [
+            {
+                "name": "coherence_floor",
+                "variable": "R",
+                "lower": 0.0,
+                "upper": 1.0,
+                "severity": "soft",
+            }
+        ],
+        "actuators": [
+            {"name": "K_global", "knob": "K", "scope": "global", "limits": [0.0, 1.0]}
+        ],
+    }
+
+
+@settings(
+    max_examples=60,
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@given(
+    name=_SAFE_TEXT,
+    layer_count=st.integers(min_value=1, max_value=5),
+    sample_period_s=st.floats(
+        min_value=1e-4, max_value=1.0, allow_nan=False, allow_infinity=False
+    ),
+    control_multiplier=st.integers(min_value=1, max_value=20),
+    base_strength=st.floats(
+        min_value=0.0, max_value=5.0, allow_nan=False, allow_infinity=False
+    ),
+    decay_alpha=st.floats(
+        min_value=0.0, max_value=5.0, allow_nan=False, allow_infinity=False
+    ),
+)
+def test_generated_binding_specs_load_and_validate(
+    tmp_path: Path,
+    name: str,
+    layer_count: int,
+    sample_period_s: float,
+    control_multiplier: int,
+    base_strength: float,
+    decay_alpha: float,
+) -> None:
+    """Generated binding specs must load and satisfy semantic validation."""
+    data = _valid_binding_data(
+        name,
+        layer_count,
+        sample_period_s,
+        control_multiplier,
+        base_strength,
+        decay_alpha,
+    )
+    path = tmp_path / "binding.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+    spec = load_binding_spec(path)
+
+    assert validate_binding_spec(spec) == []
+    assert spec.control_period_s >= spec.sample_period_s
+    assert all(layer.index >= 0 for layer in spec.layers)
+
+
+def _valid_policy_data(
+    name: str,
+    metric: str,
+    op: str,
+    threshold: float,
+    value: float,
+    ttl_s: float,
+) -> dict[str, Any]:
+    return {
+        "rules": [
+            {
+                "name": name,
+                "regime": ["NOMINAL", "DEGRADED"],
+                "condition": {
+                    "metric": metric,
+                    "layer": 0 if metric == "R" else None,
+                    "op": op,
+                    "threshold": threshold,
+                },
+                "action": {
+                    "knob": "K",
+                    "scope": "global",
+                    "value": value,
+                    "ttl_s": ttl_s,
+                },
+                "cooldown_s": 0.0,
+                "max_fires": 3,
+            }
+        ]
+    }
+
+
+@settings(
+    max_examples=60,
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@given(
+    name=_SAFE_TEXT,
+    metric=st.sampled_from(["R", "stability_proxy", "pac_max"]),
+    op=st.sampled_from([">", ">=", "<", "<=", "=="]),
+    threshold=st.floats(
+        min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False
+    ),
+    value=st.floats(
+        min_value=-1.0, max_value=1.0, allow_nan=False, allow_infinity=False
+    ),
+    ttl_s=st.floats(
+        min_value=0.0, max_value=60.0, allow_nan=False, allow_infinity=False
+    ),
+)
+def test_generated_policy_rules_load_and_evaluate(
+    tmp_path: Path,
+    name: str,
+    metric: str,
+    op: str,
+    threshold: float,
+    value: float,
+    ttl_s: float,
+) -> None:
+    """Generated policy rules must parse into finite bounded actions."""
+    path = tmp_path / "policy.yaml"
+    path.write_text(
+        yaml.safe_dump(_valid_policy_data(name, metric, op, threshold, value, ttl_s)),
+        encoding="utf-8",
+    )
+
+    rules = load_policy_rules(path)
+    engine = PolicyEngine(rules)
+    state = UPDEState(
+        layers=[LayerState(R=0.5, psi=0.0)],
+        cross_layer_alignment=np.eye(1),
+        stability_proxy=0.5,
+        regime_id="test",
+        pac_max=0.5,
+    )
+    actions = engine.evaluate(Regime.NOMINAL, state, [0], [])
+
+    assert len(rules) == 1
+    assert all(isfinite(action.value) and action.ttl_s >= 0.0 for action in actions)
+
+
+_JSON_SCALAR = (
+    st.none()
+    | st.booleans()
+    | st.integers(min_value=-10, max_value=10)
+    | st.floats(allow_nan=True, allow_infinity=True, width=32)
+    | st.text(max_size=20)
+)
+_JSONISH = st.recursive(
+    _JSON_SCALAR,
+    lambda children: (
+        st.lists(children, max_size=5)
+        | st.dictionaries(st.text(max_size=12), children, max_size=5)
+    ),
+    max_leaves=20,
+)
+
+
+@settings(
+    max_examples=80,
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@given(raw=_JSONISH)
+def test_malformed_policy_yaml_is_bounded_and_scrubbed(
+    tmp_path: Path, raw: Any
+) -> None:
+    """Malformed policy data must either load safely or fail generically."""
+    path = tmp_path / "private" / "policy.yaml"
+    path.parent.mkdir(exist_ok=True)
+    path.write_text(yaml.safe_dump(raw), encoding="utf-8")
+
+    try:
+        rules = load_policy_rules(path)
+    except ValueError as exc:
+        msg = str(exc)
+        assert "private" not in msg
+        assert str(tmp_path) not in msg
+    else:
+        assert isinstance(rules, list)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -164,6 +164,42 @@ class TestFastAPIEndpoints:
         assert "name" in data
         assert "n_oscillators" in data
 
+    def test_production_requires_api_key_env(self, monkeypatch):
+        from scpn_phase_orchestrator.server import create_app
+
+        monkeypatch.setenv("SPO_ENV", "production")
+        monkeypatch.delenv("SPO_API_KEY", raising=False)
+        with pytest.raises(RuntimeError, match="SPO_API_KEY"):
+            create_app(DOMAINPACK_DIR / "minimal_domain" / "binding_spec.yaml")
+
+    def test_production_rejects_missing_api_key(self, monkeypatch):
+        from scpn_phase_orchestrator.server import create_app
+
+        monkeypatch.setenv("SPO_ENV", "production")
+        monkeypatch.setenv("SPO_API_KEY", "test-key")
+        app = create_app(DOMAINPACK_DIR / "minimal_domain" / "binding_spec.yaml")
+        client = TestClient(app)
+
+        r = client.post("/api/step")
+
+        assert r.status_code == 401
+
+    def test_production_rate_limits_mutations(self, monkeypatch):
+        from scpn_phase_orchestrator.server import create_app
+
+        monkeypatch.setenv("SPO_ENV", "production")
+        monkeypatch.setenv("SPO_API_KEY", "test-key")
+        monkeypatch.setenv("SPO_RATE_LIMIT_PER_MINUTE", "1")
+        app = create_app(DOMAINPACK_DIR / "minimal_domain" / "binding_spec.yaml")
+        client = TestClient(app)
+        headers = {"X-API-Key": "test-key"}
+
+        first = client.post("/api/step", headers=headers)
+        second = client.post("/api/step", headers=headers)
+
+        assert first.status_code == 200
+        assert second.status_code == 429
+
 
 # Pipeline wiring: SimulationState wraps the full pipeline (binding → engine →
 # order_parameter → policy). TestSimulationState exercises step/status/reset

--- a/tests/test_server_grpc.py
+++ b/tests/test_server_grpc.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import pytest
+
 from scpn_phase_orchestrator.binding.loader import load_binding_spec
 from scpn_phase_orchestrator.grpc_gen import StateResponse, StreamRequest
 from scpn_phase_orchestrator.server import SimulationState
@@ -20,11 +22,22 @@ DOMAINPACK_DIR = Path(__file__).parent.parent / "domainpacks"
 
 
 class _FakeContext:
-    def __init__(self, active: bool = True) -> None:
+    def __init__(
+        self,
+        active: bool = True,
+        metadata: tuple[tuple[str, str], ...] = (),
+    ) -> None:
         self._active = active
+        self._metadata = metadata
 
     def is_active(self) -> bool:
         return self._active
+
+    def invocation_metadata(self) -> tuple[tuple[str, str], ...]:
+        return self._metadata
+
+    def abort(self, _code, detail: str) -> None:
+        raise PermissionError(detail)
 
 
 def _make_servicer():
@@ -99,6 +112,45 @@ def test_simulation_state_lock_is_thread_safe():
     t.start()
     t.join(timeout=2.0)
     assert acquired.is_set(), "lock not acquirable from worker thread"
+
+
+def test_grpc_production_requires_api_key_env(monkeypatch):
+    spec = load_binding_spec(DOMAINPACK_DIR / "minimal_domain" / "binding_spec.yaml")
+    sim = SimulationState(spec)
+    monkeypatch.setenv("SPO_GRPC_ENV", "production")
+    monkeypatch.delenv("SPO_GRPC_API_KEY", raising=False)
+    monkeypatch.delenv("SPO_API_KEY", raising=False)
+
+    try:
+        with pytest.raises(RuntimeError, match="SPO_GRPC_API_KEY"):
+            PhaseStreamServicer(sim)
+    finally:
+        monkeypatch.delenv("SPO_GRPC_ENV", raising=False)
+
+
+def test_grpc_production_rejects_missing_metadata(monkeypatch):
+    spec = load_binding_spec(DOMAINPACK_DIR / "minimal_domain" / "binding_spec.yaml")
+    sim = SimulationState(spec)
+    monkeypatch.setenv("SPO_GRPC_ENV", "production")
+    monkeypatch.setenv("SPO_GRPC_API_KEY", "test-key")
+    svc = PhaseStreamServicer(sim)
+
+    with pytest.raises(PermissionError, match="x-api-key"):
+        svc.GetState(None, _FakeContext())
+
+
+def test_grpc_production_rate_limits_metadata_identity(monkeypatch):
+    spec = load_binding_spec(DOMAINPACK_DIR / "minimal_domain" / "binding_spec.yaml")
+    sim = SimulationState(spec)
+    monkeypatch.setenv("SPO_GRPC_ENV", "production")
+    monkeypatch.setenv("SPO_GRPC_API_KEY", "test-key")
+    monkeypatch.setenv("SPO_GRPC_RATE_LIMIT_PER_MINUTE", "1")
+    svc = PhaseStreamServicer(sim)
+    ctx = _FakeContext(metadata=(("x-api-key", "test-key"),))
+
+    assert isinstance(svc.GetState(None, ctx), StateResponse)
+    with pytest.raises(PermissionError, match="Rate limit"):
+        svc.GetState(None, ctx)
 
 
 # Pipeline wiring: StreamPhases streams SimulationState.step() which


### PR DESCRIPTION
## Summary
- scrub endpoint/path details from Modbus, Prometheus, and QueueWaves alert failure surfaces
- add production API-key/rate-limit defaults for FastAPI, gRPC, and QueueWaves services
- harden QueueWaves config and policy-rule loading with regression and Hypothesis fuzz tests

## Local verification
- .venv-linux/bin/python -m pytest focused changed-area suite: 168 passed
- .venv-linux/bin/ruff check changed source/tests: passed
- .venv-linux/bin/python -m mypy focused changed source/tests: passed
- git diff --cached --check and staged public-name scan: passed

Full pytest/coverage pre-push gate is delegated to remote CI under the approved local-hardware override.