### PR TITLE
Raise dev pytest security floor

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 # Canonical source: pyproject.toml [project.optional-dependencies.dev]
 # Pinned versions aligned with CI_ECOSYSTEM_ANATOMY.md targets.
 -r requirements.txt
-pytest>=9.0,<10.0
+pytest>=9.0.3,<10.0
 pytest-cov>=4.1,<8.0
 hypothesis>=6.82,<7.0
 coverage[toml]>=7.3,<8.0


### PR DESCRIPTION
## Summary
- raise requirements-dev.txt pytest floor to 9.0.3 to match pyproject and the locked dependency set
- remove the remaining vulnerability scanner input for GHSA-6w46-j5rx-g56g

## Local verification
- git diff --check
- staged diff audit for prohibited provider names and suppression markers