### PR TITLE
Add adoption roadmap and N-channel binding support

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -80,3 +80,33 @@
 - ~~BoundaryObserver configurable default severity~~ (done — defaults to hard with warning)
 - ~~DP tableau deduplication between upde.rs and stuart_landau.rs~~ (done)
 - Stable public API freeze with semver guarantees
+
+### v1.0 adoption and credibility track
+
+- Ship 5-6 end-to-end tutorial notebooks that start from raw sources and finish with run, visualisation, and deterministic replay:
+  CSV sensor stream -> P channel, event log -> I channel, state-machine trace -> S channel, binding spec, engine run, supervisor decisions, actuation output, and `audit.jsonl` replay.
+- Add a visual binding-spec editor as an optional development extra. First acceptable version: load/save `binding_spec.yaml`, validate schema, expose P/I/S channel mappings, preview extractor outputs, and produce a minimal reproducible domainpack.
+- Reduce hidden YAML behaviour by documenting every inferred default in generated docs and surfacing resolved runtime configuration in CLI output and audit metadata.
+- Make the mkdocs site the primary entry point: one-page "how the pipeline fires" diagram mapping YAML -> extractors -> engines -> supervisor -> actuation, plus autodoc coverage for every public module.
+- Publish head-to-head benchmark pages for domainpacks against domain-specific baselines where appropriate, starting with power-grid swing-equation solvers and cardiac rhythm references.
+- Add reproducible build locks for application and development environments. Evaluate `uv` and `pip-tools`; keep whichever produces maintainable, hash-pinned locks across Linux, macOS, Windows, and CI.
+- Keep adapters thin and fuzzed: `hardware_io`, Modbus, OPC-UA, ROS2, Kafka, and related network/file adapters need schema fuzzing, path-scrub tests, and production-default auth/rate-limit examples.
+- Close remaining `nn/` validation xfails/skips before v1.0 unless each has an issue reference, owner, and release-blocking decision.
+
+### v1.x architecture focus
+
+- Generalise the current three-channel P/I/S model into a typed N-channel binding architecture. P/I/S remains the default profile, not the ceiling; domainpacks must be able to declare additional named channels with extractor type, units, metric semantics, coupling participation, audit serialisation, replay semantics, and supervisor visibility.
+- Add channel algebra for N-channel runs: channel groups, required/optional channels, derived channels, cross-channel coupling policies, and validation rules for missing, delayed, or uncertain channels.
+- Update audit, replay, visualisation, and reporting to be channel-count agnostic. Acceptance gate: the same run/replay/report pipeline works for three channels and for at least two domainpacks with more than three declared channels.
+- Treat Rust and JAX as primary execution paths. Keep Julia, Go, Mojo, and other auxiliary backends experimental unless a maintained production workload shows a 5-10x gain or a capability Rust/JAX cannot provide.
+- Document the backend fallback chain in one place, including feature flags, runtime detection, numerical tolerance, benchmark evidence, and deprecation criteria.
+- Add a multi-language backend review gate before each minor release: keep, demote to experimental, or remove based on maintenance cost, CI burden, and measured value.
+
+### v1.x differentiators
+
+- ML-driven auto-binding and oscillator discovery: ingest raw multimodal data, propose P/I/S or N-channel extractors, infer an initial coupling graph, and emit a reviewable binding spec.
+- Trainable supervisor policies: extend rule-based policy evaluation with reinforcement learning or active-inference loops that optimise long-horizon `R_good` / `R_bad` trade-offs under replayable safety constraints.
+- Uncertainty-aware phase estimation: Bayesian or ensemble phase estimates propagated through MPC/OA reduction and supervisor decisions.
+- Distributed edge orchestration: multi-node phase consensus with gossip or local Kuramoto coupling, plus WASM/FPGA deployment paths for decentralised operation.
+- Digital-twin binding standard: version `binding_spec.yaml` as an open bidirectional live-sync contract for simulators, services, and hardware twins.
+- Formal verification hooks: export Petri-net regimes and policy rules to PRISM, TLA+, or equivalent model-checking workflows, with CI artefacts for safety-critical policies.

--- a/docs/reference/api/drivers.md
+++ b/docs/reference/api/drivers.md
@@ -1,10 +1,10 @@
 # Drivers
 
 External forcing functions that inject the drive signal Ψ(t) into
-the Kuramoto equation. Each driver corresponds to one of the three
-oscillator channels (Physical, Informational, Symbolic) and produces
-a time-varying phase target that pulls oscillators toward a desired
-synchronisation pattern.
+the Kuramoto equation. The built-in drivers cover the standard
+physical, informational, and symbolic channel profile. Binding specs
+may also preserve named driver sections for extension channels, while
+custom actuation code decides how those channels affect Ψ(t).
 
 ## Pipeline position
 

--- a/docs/reference/api/oscillators.md
+++ b/docs/reference/api/oscillators.md
@@ -56,7 +56,7 @@ only I. The binding specification declares which channels are active.
 | `omega` | `float` | R | Instantaneous frequency (rad/s) |
 | `amplitude` | `float` | ≥ 0 | Signal strength (SNR proxy) |
 | `quality` | `float` | [0, 1] | Extraction confidence |
-| `channel` | `str` | P, I, S | Channel type |
+| `channel` | `str` | Identifier | Binding channel (`P`, `I`, `S`, or named extension) |
 | `node_id` | `str` | — | Unique oscillator identifier |
 
 Quality scores gate downstream processing: low-quality oscillators

--- a/docs/specs/binding_spec.schema.json
+++ b/docs/specs/binding_spec.schema.json
@@ -46,7 +46,8 @@
           "oscillator_ids": {
             "type": "array",
             "items": { "type": "string" }
-          }
+          },
+          "family": { "type": "string" }
         }
       },
       "minItems": 1
@@ -60,7 +61,8 @@
         "properties": {
           "channel": {
             "type": "string",
-            "enum": ["P", "I", "S"]
+            "pattern": "^[A-Za-z][A-Za-z0-9_-]{0,63}$",
+            "description": "Named phase channel. P, I, and S are the standard physical, informational, and symbolic channels; domainpacks may define additional typed channels."
           },
           "extractor_type": {
             "type": "string",
@@ -90,6 +92,7 @@
     },
     "drivers": {
       "type": "object",
+      "additionalProperties": { "type": "object" },
       "properties": {
         "physical": { "type": "object" },
         "informational": { "type": "object" },

--- a/docs/specs/phase_contract.md
+++ b/docs/specs/phase_contract.md
@@ -1,9 +1,12 @@
 # Phase Contract
 
 The Phase Contract defines the universal interface between signal sources
-(oscillators) and the UPDE integration engine. Every oscillator — physical,
-informational, or symbolic — must produce a `PhaseState` that satisfies
-this contract. Violations break the coupling pipeline downstream.
+(oscillators) and the UPDE integration engine. Every oscillator must
+produce a `PhaseState` that satisfies this contract. The standard channel
+profile is physical (`P`), informational (`I`), and symbolic (`S`), and
+domainpacks may add named channels when their extractor semantics are
+declared in the binding spec. Violations break the coupling pipeline
+downstream.
 
 ## PhaseState Fields
 
@@ -13,7 +16,7 @@ this contract. Violations break the coupling pipeline downstream.
 | `omega` | `float` | Instantaneous angular frequency, rad/s. May be negative. |
 | `amplitude` | `float` | Signal amplitude. Channel-specific meaning (see below). |
 | `quality` | `float` | Confidence in `[0, 1]`. 0 = unreliable. 1 = perfect. |
-| `channel` | `str` | `"P"`, `"I"`, or `"S"`. Set by extractor class. |
+| `channel` | `str` | Channel identifier matching `[A-Za-z][A-Za-z0-9_-]{0,63}`. |
 | `node_id` | `str` | Unique identifier for this oscillator instance. |
 
 ### Field Semantics by Channel
@@ -167,7 +170,9 @@ The following invariants hold at all times in a correctly wired pipeline:
 
 3. **Quality range**: `0 <= quality <= 1`.
 
-4. **Channel validity**: `channel in {"P", "I", "S"}`.
+4. **Channel validity**: `channel` matches
+   `[A-Za-z][A-Za-z0-9_-]{0,63}` and maps to a declared extractor
+   family. `P`, `I`, and `S` remain the standard profile.
 
 5. **Node binding**: `node_id` exists in the active binding spec.
 
@@ -231,13 +236,13 @@ def _validate(state: PhaseState) -> None:
     assert math.isfinite(state.omega)
     assert math.isfinite(state.amplitude)
     assert 0.0 <= state.quality <= 1.0
-    assert state.channel in ("P", "I", "S")
+    assert re.fullmatch(r"[A-Za-z][A-Za-z0-9_-]{0,63}", state.channel)
 ```
 
 The pipeline does not currently enforce this at the boundary (for
 performance), so extractors bear responsibility. The
 `test_phase_contract.py` test suite verifies contract compliance for
-all three built-in extractors.
+the built-in extractors.
 
 ## Pipeline Integration Example
 

--- a/src/scpn_phase_orchestrator/apps/queuewaves/config.py
+++ b/src/scpn_phase_orchestrator/apps/queuewaves/config.py
@@ -250,7 +250,10 @@ class QueueWavesConfig:
 
 def load_config(path: Path) -> QueueWavesConfig:
     """Load QueueWavesConfig from a YAML file."""
-    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (RecursionError, yaml.YAMLError):
+        raise ValueError("QueueWaves config YAML parse error") from None
     if not isinstance(raw, dict):
         msg = f"QueueWaves config must be a YAML mapping, got {type(raw).__name__}"
         raise ValueError(msg)

--- a/src/scpn_phase_orchestrator/binding/loader.py
+++ b/src/scpn_phase_orchestrator/binding/loader.py
@@ -107,10 +107,17 @@ def load_binding_spec(path: str | Path) -> BindingSpec:
     )
 
     drivers_data = _require(data, "drivers", "root")
+    standard_driver_keys = {"physical", "informational", "symbolic"}
+    extra_drivers = {
+        key: value
+        for key, value in drivers_data.items()
+        if key not in standard_driver_keys and isinstance(value, dict)
+    }
     drivers = DriverSpec(
         physical=drivers_data.get("physical", {}),
         informational=drivers_data.get("informational", {}),
         symbolic=drivers_data.get("symbolic", {}),
+        extra=extra_drivers,
     )
 
     obj = _require(data, "objectives", "root")

--- a/src/scpn_phase_orchestrator/binding/loader.py
+++ b/src/scpn_phase_orchestrator/binding/loader.py
@@ -62,7 +62,7 @@ def load_binding_spec(path: str | Path) -> BindingSpec:
 
         try:
             data = yaml.safe_load(raw)
-        except yaml.YAMLError as exc:
+        except (RecursionError, yaml.YAMLError) as exc:
             raise BindingLoadError(f"YAML parse error in {path.name}: {exc}") from exc
     elif path.suffix == ".json":
         try:

--- a/src/scpn_phase_orchestrator/binding/types.py
+++ b/src/scpn_phase_orchestrator/binding/types.py
@@ -8,6 +8,7 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 
 from scpn_phase_orchestrator.exceptions import ValidationError
@@ -25,11 +26,13 @@ __all__ = [
     "ProtocolNetSpec",
     "AmplitudeSpec",
     "VALID_CHANNELS",
+    "STANDARD_CHANNELS",
     "VALID_SEVERITIES",
     "VALID_KNOBS",
     "VALID_SAFETY_TIERS",
     "EXTRACTOR_ALIASES",
     "VALID_EXTRACTORS",
+    "is_valid_channel_id",
     "resolve_extractor_type",
     "BindingSpec",
 ]
@@ -48,9 +51,9 @@ class HierarchyLayer:
 
 @dataclass(frozen=True)
 class OscillatorFamily:
-    """Phase extraction configuration for one oscillator group (P/I/S channel)."""
+    """Phase extraction configuration for one oscillator group."""
 
-    channel: str  # "P", "I", or "S"
+    channel: str
     extractor_type: str
     config: dict
 
@@ -66,11 +69,36 @@ class CouplingSpec:
 
 @dataclass(frozen=True)
 class DriverSpec:
-    """Configuration for P/I/S external driver channels."""
+    """Configuration for standard and named external driver channels."""
 
     physical: dict
     informational: dict
     symbolic: dict
+    extra: dict[str, dict] | None = None
+
+    def channel_config(self, channel: str) -> dict:
+        """Return driver config for a standard or named channel."""
+        standard = {
+            "P": self.physical,
+            "physical": self.physical,
+            "I": self.informational,
+            "informational": self.informational,
+            "S": self.symbolic,
+            "symbolic": self.symbolic,
+        }
+        if channel in standard:
+            return standard[channel]
+        return (self.extra or {}).get(channel, {})
+
+    def all_channel_configs(self) -> dict[str, dict]:
+        """Return standard driver configs plus named extension channels."""
+        configs = {
+            "P": self.physical,
+            "I": self.informational,
+            "S": self.symbolic,
+        }
+        configs.update(self.extra or {})
+        return configs
 
 
 @dataclass(frozen=True)
@@ -163,7 +191,9 @@ class AmplitudeSpec:
     amp_coupling_decay: float = 0.3
 
 
-VALID_CHANNELS = frozenset({"P", "I", "S"})
+STANDARD_CHANNELS = frozenset({"P", "I", "S"})
+VALID_CHANNELS = STANDARD_CHANNELS
+_CHANNEL_ID_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_-]{0,63}$")
 VALID_SEVERITIES = frozenset({"soft", "hard"})
 VALID_KNOBS = frozenset({"K", "alpha", "zeta", "Psi"})
 VALID_SAFETY_TIERS = frozenset({"research", "clinical", "consumer", "production"})
@@ -186,6 +216,11 @@ EXTRACTOR_ALIASES: dict[str, str] = {
     "symbolic": "ring",
 }
 VALID_EXTRACTORS = _ALGORITHM_EXTRACTORS | frozenset(EXTRACTOR_ALIASES)
+
+
+def is_valid_channel_id(channel: str) -> bool:
+    """Return True when *channel* is a valid binding channel identifier."""
+    return bool(_CHANNEL_ID_RE.fullmatch(channel))
 
 
 def resolve_extractor_type(raw: str) -> str:

--- a/src/scpn_phase_orchestrator/binding/validator.py
+++ b/src/scpn_phase_orchestrator/binding/validator.py
@@ -9,12 +9,12 @@
 from __future__ import annotations
 
 from scpn_phase_orchestrator.binding.types import (
-    VALID_CHANNELS,
     VALID_EXTRACTORS,
     VALID_KNOBS,
     VALID_SAFETY_TIERS,
     VALID_SEVERITIES,
     BindingSpec,
+    is_valid_channel_id,
 )
 
 __all__ = ["validate_binding_spec"]
@@ -51,10 +51,11 @@ def validate_binding_spec(spec: BindingSpec) -> list[str]:
     layer_indices = {lay.index for lay in spec.layers}
 
     for family_name, fam in spec.oscillator_families.items():
-        if fam.channel not in VALID_CHANNELS:
+        if not is_valid_channel_id(fam.channel):
             errors.append(
-                f"oscillator_family {family_name!r}: channel must be one of "
-                f"{VALID_CHANNELS}, got {fam.channel!r}"
+                f"oscillator_family {family_name!r}: channel must be a non-empty "
+                f"identifier matching [A-Za-z][A-Za-z0-9_-]{{0,63}}, got "
+                f"{fam.channel!r}"
             )
         if fam.extractor_type not in VALID_EXTRACTORS:
             errors.append(

--- a/src/scpn_phase_orchestrator/cli.py
+++ b/src/scpn_phase_orchestrator/cli.py
@@ -217,9 +217,8 @@ def run(binding_spec: str, steps: int, audit: str | None, seed: int) -> None:
 
     # Initialise drive parameters from spec.drivers
     zeta = max(
-        spec.drivers.physical.get("zeta", 0.0),
-        spec.drivers.informational.get("zeta", 0.0),
-        spec.drivers.symbolic.get("zeta", 0.0),
+        (cfg.get("zeta", 0.0) for cfg in spec.drivers.all_channel_configs().values()),
+        default=0.0,
     )
     zeta_ttl = 0
     psi_target = spec.drivers.physical.get("psi", 0.0)

--- a/src/scpn_phase_orchestrator/monitor/session_start.py
+++ b/src/scpn_phase_orchestrator/monitor/session_start.py
@@ -43,7 +43,7 @@ def check_session_start(
     """Validate extraction quality, imprint consistency, and initial coherence.
 
     Args:
-        phase_states: extracted P/I/S states from all oscillators.
+        phase_states: extracted states from all configured channels.
         initial_phases: phase array that will seed the UPDE engine.
         imprint_state: loaded (or fresh) imprint state.
         n_osc: expected oscillator count.
@@ -55,7 +55,7 @@ def check_session_start(
     scorer = PhaseQualityScorer()
 
     # Quality per channel
-    by_channel: dict[str, list[PhaseState]] = {"P": [], "I": [], "S": []}
+    by_channel: dict[str, list[PhaseState]] = {}
     for ps in phase_states:
         by_channel.setdefault(ps.channel, []).append(ps)
 

--- a/src/scpn_phase_orchestrator/oscillators/base.py
+++ b/src/scpn_phase_orchestrator/oscillators/base.py
@@ -24,7 +24,7 @@ class PhaseState:
     omega: float  # instantaneous frequency, rad/s
     amplitude: float
     quality: float  # 0..1
-    channel: str  # "P", "I", or "S"
+    channel: str
     node_id: str
 
 

--- a/src/scpn_phase_orchestrator/oscillators/init_phases.py
+++ b/src/scpn_phase_orchestrator/oscillators/init_phases.py
@@ -4,7 +4,7 @@
 # © Code 2020–2026 Miroslav Šotek. All rights reserved.
 # ORCID: 0009-0009-3560-0851
 # Contact: www.anulum.li | protoscience@anulum.li
-# SCPN Phase Orchestrator — P/I/S phase initialization
+# SCPN Phase Orchestrator — Binding-channel phase initialization
 
 from __future__ import annotations
 
@@ -19,6 +19,9 @@ from scpn_phase_orchestrator.oscillators.symbolic import SymbolicExtractor
 __all__ = ["extract_initial_phases"]
 
 TWO_PI = 2.0 * np.pi
+_PHYSICAL_EXTRACTORS = frozenset({"hilbert", "wavelet", "zero_crossing"})
+_INFORMATIONAL_EXTRACTORS = frozenset({"event"})
+_SYMBOLIC_EXTRACTORS = frozenset({"ring", "graph"})
 
 
 def extract_initial_phases(
@@ -26,11 +29,11 @@ def extract_initial_phases(
     omegas: NDArray,
     seed: int = 42,
 ) -> NDArray:
-    """Extract initial phases from P/I/S channels defined in binding_spec.
+    """Extract initial phases from channels defined in binding_spec.
 
-    For each oscillator, generates a synthetic signal matching its channel
-    type and extracts the phase. Falls back to random phase if extraction
-    fails.
+    For each oscillator, generates a synthetic signal matching the family
+    channel or extractor semantics and extracts the phase. Falls back to
+    random phase if extraction fails.
 
     Returns (n_osc,) array of initial phases in [0, 2*pi).
     """
@@ -40,32 +43,28 @@ def extract_initial_phases(
     t = np.linspace(0, 1.0, 256)
 
     families = spec.oscillator_families
-    family_channels = {}
-    family_configs = {}
-    for name, fam in families.items():
-        family_channels[name] = fam.channel
-        family_configs[name] = fam.config or {}
-
     osc_idx = 0
     for layer in spec.layers:
         for osc_id in layer.oscillator_ids:
             omega = omegas[osc_idx]
-            channel = _resolve_channel(layer.family, families, osc_idx)
+            family = _resolve_family(layer.family, families, osc_idx)
+            channel = family.channel if family is not None else "P"
+            extractor_type = family.extractor_type if family is not None else "hilbert"
 
-            if channel == "P":
+            if channel == "P" or extractor_type in _PHYSICAL_EXTRACTORS:
                 signal = np.sin(omega * TWO_PI * t) + rng.normal(0, 0.1, len(t))
                 p_ext = PhysicalExtractor(node_id=osc_id)
                 states = p_ext.extract(signal, sample_rate=256.0)
                 phases[osc_idx] = states[-1].theta if states else rng.uniform(0, TWO_PI)
 
-            elif channel == "I":
+            elif channel == "I" or extractor_type in _INFORMATIONAL_EXTRACTORS:
                 n_events = max(3, int(omega * 10))
                 timestamps = np.sort(rng.uniform(0, 1.0, n_events))
                 i_ext = InformationalExtractor(node_id=osc_id)
                 states = i_ext.extract(timestamps, sample_rate=1.0)
                 phases[osc_idx] = states[-1].theta if states else rng.uniform(0, TWO_PI)
 
-            elif channel == "S":
+            elif channel == "S" or extractor_type in _SYMBOLIC_EXTRACTORS:
                 n_states = _get_n_states(families)
                 state_idx = rng.integers(0, n_states)
                 s_ext = SymbolicExtractor(n_states=n_states, node_id=osc_id)
@@ -86,22 +85,30 @@ def _resolve_channel(
     osc_idx: int,
 ) -> str:
     """Resolve channel from explicit family binding or round-robin fallback."""
+    family = _resolve_family(layer_family, families, osc_idx)
+    if family is not None:
+        return family.channel
+    return "P"
+
+
+def _resolve_family(
+    layer_family: str | None,
+    families: dict[str, OscillatorFamily],
+    osc_idx: int,
+) -> OscillatorFamily | None:
+    """Resolve family from explicit layer binding or round-robin fallback."""
     if layer_family is not None and layer_family in families:
-        return families[layer_family].channel
-    channels = []
-    for key in sorted(families.keys()):
-        ch = families[key].channel
-        if ch not in channels:
-            channels.append(ch)
-    if not channels:
-        return "P"
-    return channels[osc_idx % len(channels)]
+        return families[layer_family]
+    ordered = [families[key] for key in sorted(families)]
+    if not ordered:
+        return None
+    return ordered[osc_idx % len(ordered)]
 
 
 def _get_n_states(families: dict[str, OscillatorFamily]) -> int:
-    """Find n_states from the first symbolic family."""
+    """Find n_states from the first symbolic-family extractor."""
     for fam in families.values():
-        if fam.channel == "S":
+        if fam.channel == "S" or fam.extractor_type in _SYMBOLIC_EXTRACTORS:
             cfg = fam.config or {}
             return int(cfg.get("n_states", 4))
     return 4

--- a/src/scpn_phase_orchestrator/supervisor/policy_rules.py
+++ b/src/scpn_phase_orchestrator/supervisor/policy_rules.py
@@ -324,7 +324,7 @@ def load_policy_rules(path: str | Path) -> list[PolicyRule]:
         raise ValueError(f"cannot read policy rules: {reason}") from None
     try:
         data = yaml.safe_load(raw)
-    except yaml.YAMLError:
+    except (RecursionError, yaml.YAMLError):
         raise ValueError("policy rules YAML parse error") from None
     if not isinstance(data, dict) or "rules" not in data:
         return []

--- a/tests/apps/queuewaves/test_config.py
+++ b/tests/apps/queuewaves/test_config.py
@@ -71,6 +71,24 @@ def test_load_config(tmp_path: Path) -> None:
     assert cfg.security.rate_limit_per_minute == 240
 
 
+def test_load_config_recursion_error_is_parse_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from scpn_phase_orchestrator.apps.queuewaves import config as config_mod
+
+    path = tmp_path / "qw.yaml"
+    path.write_text(
+        "prometheus_url: http://prom:9090\nservices: []\n", encoding="utf-8"
+    )
+
+    def raise_recursion(_: str) -> object:
+        raise RecursionError("nested YAML")
+
+    monkeypatch.setattr(config_mod.yaml, "safe_load", raise_recursion)
+    with pytest.raises(ValueError, match="QueueWaves config YAML parse error"):
+        load_config(path)
+
+
 def test_config_compiler_layers(minimal_config: QueueWavesConfig) -> None:
     compiler = ConfigCompiler()
     spec = compiler.compile(minimal_config)

--- a/tests/test_binding_loader.py
+++ b/tests/test_binding_loader.py
@@ -130,6 +130,26 @@ def test_loader_passes_algorithm_names_through(tmp_path):
     assert spec.oscillator_families["g"].extractor_type == "graph"
 
 
+def test_loader_preserves_named_driver_channels(tmp_path):
+    data = {
+        **_SPEC_DATA,
+        "drivers": {
+            "physical": {},
+            "informational": {},
+            "symbolic": {},
+            "Q": {"zeta": 0.25},
+            "edge-node": {"psi": 1.5},
+        },
+    }
+    p = tmp_path / "spec.json"
+    p.write_text(json.dumps(data), encoding="utf-8")
+    spec = load_binding_spec(p)
+
+    assert spec.drivers.channel_config("Q") == {"zeta": 0.25}
+    assert spec.drivers.channel_config("edge-node") == {"psi": 1.5}
+    assert spec.drivers.all_channel_configs()["Q"] == {"zeta": 0.25}
+
+
 def test_json_yaml_produce_identical_spec(tmp_path):
     """Loading the same spec from JSON and YAML must produce identical BindingSpec."""
     yaml = pytest.importorskip("yaml")
@@ -186,7 +206,11 @@ def test_loader_validate_control_period_and_channels(tmp_path):
         **_SPEC_DATA,
         "control_period_s": -1.0,
         "oscillator_families": {
-            "bad": {"channel": "X", "extractor_type": "hilbert", "config": {}},
+            "bad": {
+                "channel": "bad channel",
+                "extractor_type": "hilbert",
+                "config": {},
+            },
         },
         "boundaries": [
             {

--- a/tests/test_binding_loader_security.py
+++ b/tests/test_binding_loader_security.py
@@ -37,6 +37,21 @@ class TestMalformedYAML:
         with pytest.raises(BindingLoadError, match="YAML parse error"):
             load_binding_spec(p)
 
+    def test_yaml_recursion_error_is_parse_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import yaml
+
+        p = tmp_path / "recursive.yaml"
+        p.write_text("rules: []\n", encoding="utf-8")
+
+        def raise_recursion(_: str) -> object:
+            raise RecursionError("nested YAML")
+
+        monkeypatch.setattr(yaml, "safe_load", raise_recursion)
+        with pytest.raises(BindingLoadError, match="YAML parse error"):
+            load_binding_spec(p)
+
 
 class TestInvalidJSON:
     def test_truncated_json(self, tmp_path: Path) -> None:

--- a/tests/test_binding_validator.py
+++ b/tests/test_binding_validator.py
@@ -51,9 +51,13 @@ def test_negative_sample_period(sample_binding_spec):
     assert any("sample_period_s" in e for e in errors)
 
 
-def test_invalid_channel(sample_binding_spec):
+def test_invalid_channel_identifier(sample_binding_spec):
     bad_families = {
-        "x": OscillatorFamily(channel="X", extractor_type="hilbert", config={}),
+        "x": OscillatorFamily(
+            channel="bad channel",
+            extractor_type="hilbert",
+            config={},
+        ),
     }
     bad = replace(sample_binding_spec, oscillator_families=bad_families)
     errors = validate_binding_spec(bad)
@@ -138,8 +142,8 @@ def test_all_valid_safety_tiers_accepted(sample_binding_spec):
 
 
 def test_valid_channels_accepted(sample_binding_spec):
-    """Channels P, I, S must all pass validation."""
-    for ch in ["P", "I", "S"]:
+    """Standard and named extension channels must pass validation."""
+    for ch in ["P", "I", "S", "Q", "sensor_4", "edge-node"]:
         families = {
             "f": OscillatorFamily(channel=ch, extractor_type="hilbert", config={}),
         }

--- a/tests/test_init_phases.py
+++ b/tests/test_init_phases.py
@@ -4,7 +4,7 @@
 # © Code 2020–2026 Miroslav Šotek. All rights reserved.
 # ORCID: 0009-0009-3560-0851
 # Contact: www.anulum.li | protoscience@anulum.li
-# SCPN Phase Orchestrator — Tests for P/I/S initial phase extraction
+# SCPN Phase Orchestrator — Tests for binding-channel initial phase extraction
 
 from __future__ import annotations
 
@@ -93,6 +93,52 @@ def test_different_seeds_differ():
     a = extract_initial_phases(spec, omegas, seed=1)
     b = extract_initial_phases(spec, omegas, seed=2)
     assert not np.array_equal(a, b)
+
+
+def test_named_channels_route_by_extractor_semantics():
+    layers = [
+        HierarchyLayer(
+            name="L1",
+            index=0,
+            oscillator_ids=["osc0", "osc1", "osc2", "osc3"],
+        ),
+    ]
+    families = {
+        "fast": OscillatorFamily(channel="Q", extractor_type="hilbert", config={}),
+        "events": OscillatorFamily(channel="C", extractor_type="event", config={}),
+        "modes": OscillatorFamily(
+            channel="M", extractor_type="ring", config={"n_states": 7}
+        ),
+        "edge": OscillatorFamily(
+            channel="edge-node",
+            extractor_type="graph",
+            config={},
+        ),
+    }
+    spec = BindingSpec(
+        name="test-n-channel",
+        version="1.0.0",
+        safety_tier="research",
+        sample_period_s=0.01,
+        control_period_s=0.1,
+        layers=layers,
+        oscillator_families=families,
+        coupling=CouplingSpec(base_strength=0.45, decay_alpha=0.3, templates={}),
+        drivers=DriverSpec(
+            physical={},
+            informational={},
+            symbolic={},
+            extra={"Q": {"zeta": 0.1}, "C": {"zeta": 0.2}},
+        ),
+        objectives=ObjectivePartition(good_layers=[0], bad_layers=[]),
+        boundaries=[],
+        actuators=[],
+    )
+    phases = extract_initial_phases(spec, np.array([1.0, 2.0, 3.0, 4.0]), seed=42)
+
+    assert phases.shape == (4,)
+    assert np.all(phases >= 0.0)
+    assert np.all(phases < TWO_PI)
 
 
 class TestInitPhasesPipelineWiring:

--- a/tests/test_policy_rules.py
+++ b/tests/test_policy_rules.py
@@ -9,6 +9,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 
 from scpn_phase_orchestrator.supervisor.policy_rules import (
     CompoundCondition,
@@ -122,6 +123,20 @@ def test_load_empty_policy_yaml(tmp_path):
     p = tmp_path / "policy.yaml"
     p.write_text("rules: []\n", encoding="utf-8")
     assert load_policy_rules(p) == []
+
+
+def test_load_policy_rules_recursion_error_is_parse_error(tmp_path, monkeypatch):
+    import yaml
+
+    p = tmp_path / "policy.yaml"
+    p.write_text("rules: []\n", encoding="utf-8")
+
+    def raise_recursion(_: str) -> object:
+        raise RecursionError("nested YAML")
+
+    monkeypatch.setattr(yaml, "safe_load", raise_recursion)
+    with pytest.raises(ValueError, match="policy rules YAML parse error"):
+        load_policy_rules(p)
 
 
 def test_out_of_range_layer_returns_none():

--- a/tests/test_session_start.py
+++ b/tests/test_session_start.py
@@ -117,6 +117,17 @@ def test_multi_channel_quality_scores():
     assert report.quality_scores["P"] > report.quality_scores["S"]
 
 
+def test_named_extension_channel_quality_score():
+    n = 5
+    states = _make_states(n, quality=0.8, channel="Q")
+    phases = np.zeros(n)
+    imprint = ImprintState(m_k=np.zeros(n), last_update=0.0)
+
+    report = check_session_start(states, phases, imprint, n)
+    assert report.passed
+    assert report.quality_scores["Q"] == 0.8
+
+
 def test_low_initial_coherence_warns():
     n = 10
     states = _make_states(n, quality=0.8)


### PR DESCRIPTION
## Summary
- Adds the adoption/credibility roadmap track and records N-channel binding as a v1.x architecture focus.
- Implements the first N-channel slice: binding validation accepts named channels, the loader preserves named driver sections, initial phase seeding routes by extractor semantics, and session-start quality scoring handles arbitrary channels.
- Updates binding/phase docs and focused regression tests for named channels.

## Local validation
- .venv-linux/bin/ruff check src/scpn_phase_orchestrator/binding src/scpn_phase_orchestrator/oscillators src/scpn_phase_orchestrator/monitor/session_start.py src/scpn_phase_orchestrator/cli.py tests/test_binding_validator.py tests/test_binding_loader.py tests/test_init_phases.py tests/test_session_start.py
- .venv-linux/bin/python -m pytest tests/test_binding_validator.py tests/test_binding_loader.py tests/test_init_phases.py tests/test_session_start.py

Co-Authored-By: Arcane Sapience <protoscience@anulum.li>