### PR TITLE
Expose resolved binding configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 
 .DEFAULT_GOAL := help
 
-.PHONY: help install install-dev test test-rust test-all lint fmt bandit sast \
+.PHONY: help install install-dev quickstart test test-rust test-all lint fmt bandit sast \
         preflight preflight-fast docs docs-build bench bench-rust bridge \
         build docker-build docker-run clean install-hooks
 
@@ -20,6 +20,14 @@ install:  ## Install package
 
 install-dev:  ## Install with dev dependencies
 	pip install -e ".[dev,queuewaves,plot,notebook]"
+
+quickstart:  ## Create dev venv, install extras, run minimal audited demo
+	python -m venv .venv
+	.venv/bin/python -m pip install --upgrade pip
+	.venv/bin/python -m pip install -e ".[dev,queuewaves,plot,notebook]"
+	.venv/bin/spo validate domainpacks/minimal_domain/binding_spec.yaml
+	.venv/bin/spo run domainpacks/minimal_domain/binding_spec.yaml --steps 50 --audit /tmp/spo-quickstart-audit.jsonl
+	.venv/bin/spo report /tmp/spo-quickstart-audit.jsonl
 
 test:  ## Run Python tests with coverage
 	pytest tests/ -v --tb=short --cov=scpn_phase_orchestrator --cov-report=term-missing

--- a/docs/concepts/pipeline_execution.md
+++ b/docs/concepts/pipeline_execution.md
@@ -1,0 +1,120 @@
+# Pipeline Execution
+
+This page shows how a binding file becomes a controlled simulation run.
+It is the shortest path from YAML fields to runtime behaviour.
+
+## One-Page Flow
+
+```mermaid
+flowchart TD
+    A[binding_spec.yaml] --> B[Binding loader]
+    B --> C[Validation]
+    C --> D[Resolved binding config]
+    D --> E[Layer and channel map]
+    D --> F[Coupling builder]
+    D --> G[Driver setup]
+    E --> H[Phase initialisation]
+    F --> I[Engine step]
+    G --> I
+    H --> I
+    I --> J[Layer order parameters]
+    J --> K[Boundary observer]
+    K --> L[Regime manager]
+    L --> M[Supervisor policy]
+    M --> N[Action projector]
+    N --> O[Control knobs: K, alpha, zeta, Psi]
+    O --> I
+    I --> P[Audit JSONL]
+    M --> P
+```
+
+## What `spo validate` Resolves
+
+`spo validate <binding_spec>` does more than say that YAML is syntactically
+valid. It now prints the resolved runtime summary:
+
+```text
+Valid
+Resolved configuration:
+  domain: minimal_domain v0.1.0 (research)
+  timing: sample=0.01s control=0.1s interval=10 steps
+  structure: layers=3 oscillators=6 channels=I, P, S
+  engine: kuramoto features=none
+  channel P: families=physical extractors=hilbert driver_keys=none layers=1 oscillators=2
+```
+
+Use this block to check that the binding spec means what you think it means
+before running a simulation.
+
+## YAML To Runtime Mapping
+
+| YAML field | Runtime object | Used for |
+|------------|----------------|----------|
+| `name`, `version`, `safety_tier` | binding metadata | audit headers, operator context |
+| `sample_period_s` | engine `dt` | integration timestep |
+| `control_period_s` | control interval | supervisor cadence in steps |
+| `layers` | layer ranges | per-layer `R`, objectives, scoped actions |
+| `oscillator_families` | channel and extractor map | P/I/S or named-channel routing |
+| `coupling` | `CouplingState` | `K_nm`, lag `alpha`, active template |
+| `drivers` | drive initialisation | `zeta`, `Psi`, physical/event/symbolic drive |
+| `objectives` | good/bad partitions | final `R_good`, `R_bad`, policy metrics |
+| `boundaries` | `BoundaryObserver` | soft/hard violation events |
+| `actuators` | `ActionProjector` bounds | clipping and rate-limited actuation |
+| `imprint_model` | `ImprintModel` | slow memory modulation of coupling |
+| `geometry_prior` | coupling projection | symmetry or non-negative constraints |
+| `protocol_net` | Petri-net adapter | regime sequencing FSM |
+| `amplitude` | `StuartLandauEngine` | phase plus amplitude dynamics |
+
+## Execution Steps
+
+1. Load and validate the binding file.
+2. Build the resolved binding summary from the validated `BindingSpec`.
+3. Count oscillators from `layers`.
+4. Build `K_nm` and `alpha` from `coupling`.
+5. Select `UPDEEngine` or `StuartLandauEngine` from `amplitude`.
+6. Build optional protocol, imprint, geometry, and policy-rule components.
+7. Initialise phases and natural frequencies.
+8. Resolve driver state from `drivers`.
+9. Every integration step:
+   - apply driver and control inputs,
+   - project coupling if a geometry prior is enabled,
+   - advance the engine,
+   - compute layer order parameters,
+   - evaluate boundaries,
+   - update the regime and policy,
+   - project actions through rate and value limits,
+   - write audit state if audit logging is enabled.
+10. Print final `R_good`, `R_bad`, and regime.
+
+## Audit Header
+
+When `spo run --audit run.jsonl` is used, the first audit record includes
+the same resolved binding summary. It records structural runtime choices and
+driver key names, not raw driver values. That keeps replay/debug metadata useful
+without copying endpoint strings or deployment-local values into audit logs.
+
+The header is intended for:
+
+- replay context,
+- support triage,
+- domainpack review,
+- explaining why a run used a given engine, channel map, or control cadence.
+
+## Common Misreads Caught By The Summary
+
+| Symptom | What to inspect |
+|---------|-----------------|
+| Wrong control cadence | `timing: ... interval=N steps` |
+| Missing named channel | `structure: ... channels=...` |
+| Driver ignored | `channel X: ... driver_keys=...` |
+| Unbound layers | `note: N layer(s) have no explicit oscillator family binding` |
+| Wrong engine | `engine: kuramoto` vs `engine: stuart_landau` |
+| Optional model not active | `features=...` |
+
+For a first run, use:
+
+```bash
+spo validate domainpacks/minimal_domain/binding_spec.yaml
+spo run domainpacks/minimal_domain/binding_spec.yaml --steps 100 --audit run.jsonl
+spo report run.jsonl
+```

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -18,6 +18,15 @@ pip install -e ".[dev]"
 
 The `dev` extra includes pytest, hypothesis, ruff, mypy, bandit, coverage, mkdocs-material, pre-commit, and twine.
 
+For a full local setup plus a minimal audited smoke run:
+
+```bash
+make quickstart
+```
+
+The target creates `.venv`, installs development extras, validates the
+minimal domainpack, runs `spo run`, and reports the generated audit log.
+
 ## Optional Extras
 
 | Extra | Installs | Purpose |

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -8,6 +8,16 @@ Five minutes from install to synchronized oscillators.
 pip install scpn-phase-orchestrator
 ```
 
+For repository development, use the one-command setup and smoke run:
+
+```bash
+make quickstart
+```
+
+That target creates `.venv`, installs the development extras, validates
+`domainpacks/minimal_domain/binding_spec.yaml`, runs a short audited
+simulation, and prints a coherence report.
+
 ## 2. Your First Simulation
 
 8 Kuramoto oscillators with uniform coupling, integrated for 500 RK4 steps:

--- a/docs/getting-started/start_here.md
+++ b/docs/getting-started/start_here.md
@@ -220,6 +220,8 @@ After your entry point:
   how to set coupling strengths.
 - **Deployment:** [Hardware Guide](../guide/hardware_deployment.md) —
   Rust FFI, FPGA, WASM, GPU, Docker.
+- **Deployment:** [Backend Strategy](../guide/backend_strategy.md) —
+  Rust and JAX primary paths, Python fallback, experimental backends.
 - **Domains:** [Domainpack Gallery](../galleries/domainpack_gallery.md)
   — 24 domains.
 - **API:** [Full API Reference](../reference/api/index.md)

--- a/docs/getting-started/start_here.md
+++ b/docs/getting-started/start_here.md
@@ -202,6 +202,9 @@ After your entry point:
 
 - **Concepts:** [Control Knobs K/alpha/zeta/Psi](../concepts/knobs_K_alpha_zeta_Psi.md)
   — the four parameters you can adjust.
+- **Concepts:** [Pipeline Execution](../concepts/pipeline_execution.md)
+  — how binding YAML resolves into extractors, engines, supervisor
+  actions, and audit records.
 - **Concepts:** [Phase Contract](../specs/phase_contract.md) — what
   every oscillator must produce.
 - **Concepts:** [Oscillators P/I/S](../concepts/oscillators_PIS.md) —

--- a/docs/guide/backend_strategy.md
+++ b/docs/guide/backend_strategy.md
@@ -1,0 +1,117 @@
+# Backend Strategy
+
+SCPN Phase Orchestrator has several implementation backends. The supported
+path is deliberately narrow:
+
+1. Rust FFI for production hot paths.
+2. JAX for differentiable and accelerator-oriented workflows.
+3. NumPy/SciPy Python as the portable reference fallback.
+4. Julia, Go, and Mojo as experimental parity or benchmark backends.
+
+Use this page to decide which backend should carry a deployment.
+
+## Support Tiers
+
+| Tier | Backend | Status | Use for |
+|------|---------|--------|---------|
+| Primary | Rust FFI (`spo_kernel`) | production path | low-latency CPU stepping, monitors, coupling, supervisor hot paths |
+| Primary | JAX | production path for differentiable work | gradient-based training, GPU/TPU experiments, learned policies |
+| Reference | NumPy/SciPy Python | always available | correctness, portability, debugging, fallback execution |
+| Experimental | Julia | benchmark/parity | numerical experiments that prove a clear advantage |
+| Experimental | Go | benchmark/parity | deployment experiments that prove operational simplicity or speed |
+| Experimental | Mojo | benchmark/parity | compiler/runtime experiments |
+
+Experimental backends should not become the default path unless they show a
+clear 5-10x production advantage for a real workload and have CI parity tests.
+
+## Runtime Selection
+
+The runtime preference is:
+
+```text
+Rust FFI available and supported for this module
+    -> use Rust
+else JAX workflow explicitly selected
+    -> use JAX APIs
+else
+    -> use NumPy/SciPy Python fallback
+```
+
+Julia, Go, and Mojo are not automatic production fallbacks. Treat them as
+opt-in experiments until their maintenance cost is justified by measured value.
+
+## Rust Path
+
+Rust is the primary acceleration path for CPU-bound production work.
+
+Use it when:
+
+- `spo_kernel` is installable on the deployment target,
+- the workload is latency-sensitive,
+- the hot path is already covered by Rust parity tests,
+- deterministic CPU execution matters more than autodiff.
+
+Build it with:
+
+```bash
+maturin develop --release -m spo-kernel/crates/spo-ffi/Cargo.toml
+```
+
+Python classes auto-detect `spo_kernel` and delegate supported hot paths with
+no API change.
+
+## JAX Path
+
+JAX is the primary path for differentiable orchestration.
+
+Use it when:
+
+- coupling or policy parameters are learned,
+- gradients need to flow through phase dynamics,
+- GPU/TPU acceleration is part of the experiment,
+- the workflow lives in `nn/`, UDE, or differentiable Kuramoto modules.
+
+JAX should not replace the Rust path for ordinary CPU production stepping unless
+measurements show it is better for that workload.
+
+## Python Reference Path
+
+The Python path is the correctness baseline. It is always available and should
+remain readable, deterministic, and well tested.
+
+Use it when:
+
+- debugging a new model,
+- reproducing a bug without native extensions,
+- validating Rust or JAX parity,
+- supporting platforms where native builds are not available.
+
+The Python path is not a failure mode. It is the portable reference
+implementation.
+
+## Experimental Backends
+
+Julia, Go, and Mojo backends stay experimental unless they meet all promotion
+criteria:
+
+- reproducible benchmark showing at least 5-10x improvement on a production
+  workload, or a deployment capability Rust/JAX cannot provide,
+- parity tests against the Python reference,
+- CI coverage on the target platform,
+- clear owner and maintenance story,
+- documented fallback if the backend is unavailable.
+
+If those criteria are not met, keep the backend under experiments, benchmarks,
+or explicit optional code paths.
+
+## Contribution Rules
+
+New backend code should answer these questions in the PR:
+
+- What production workload does it improve?
+- Which primary backend does it replace or complement?
+- What is the measured speed, memory, or deployment advantage?
+- Which parity tests prove equivalent numerical behaviour?
+- What happens when the backend is missing?
+
+Without those answers, prefer improving Rust, JAX, or the Python reference path.

--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -46,7 +46,8 @@ are copied since the scratch buffer is reused across stages.
 When `spo_kernel` is installed, 53 engine modules delegate hot paths to
 Rust automatically. Speedups range from 2x to 96x depending on the module
 and N. See [Rust FFI Acceleration](rust_ffi.md) for build instructions
-and the full module table.
+and the full module table. For backend support tiers and fallback rules, see
+[Backend Strategy](backend_strategy.md).
 
 **Note:** Two modules (coupling_est, phase_extract) have Rust auto-select
 disabled because LAPACK lstsq and SciPy FFT respectively outperform the

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -26,12 +26,24 @@ spo validate <binding_spec>
 | 0 | Valid specification |
 | 1 | Validation errors found |
 
-**Output:** List of validation errors (one per line) or `Valid`.
+**Output:** List of validation errors (one per line) or `Valid` followed by
+the resolved binding configuration summary.
 
 **Example:**
 
 ```bash
 spo validate domainpacks/bio_stub/binding_spec.yaml
+```
+
+Example success output:
+
+```text
+Valid
+Resolved configuration:
+  domain: bio_stub v0.1.0 (research)
+  timing: sample=0.01s control=0.1s interval=10 steps
+  structure: layers=3 oscillators=6 channels=I, P, S
+  engine: kuramoto features=none
 ```
 
 ---
@@ -58,8 +70,9 @@ spo run <binding_spec> [OPTIONS]
 | `--audit PATH` | None | Write audit log to JSONL file |
 | `--seed INT` | None | RNG seed for reproducibility |
 
-**Output:** Per-step regime, R_global, boundary violations, and policy actions
-printed to stdout.
+**Output:** Resolved binding configuration, then final `R_good`, `R_bad`, and
+regime. If `--audit` is set, the audit header contains the same resolved
+configuration summary.
 
 **Example:**
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,7 @@ nav:
       - Stuart-Landau Amplitude Mode: guide/stuart_landau.md
       - QueueWaves Cascade Detector: guide/queuewaves.md
       - Rust FFI Acceleration: guide/rust_ffi.md
+      - Backend Strategy: guide/backend_strategy.md
       - Adapter Bridges: guide/adapters.md
       - Performance Tuning: guide/performance.md
       - Production Deployment: guide/production.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,7 @@ nav:
       - Start Here (Learning Path): getting-started/start_here.md
   - Concepts:
       - System Overview: concepts/system_overview.md
+      - Pipeline Execution: concepts/pipeline_execution.md
       - "Oscillators & PIS": concepts/oscillators_PIS.md
       - "Knobs: K, α, ζ, Ψ": concepts/knobs_K_alpha_zeta_Psi.md
       - Memory Imprint: concepts/memory_imprint.md

--- a/src/scpn_phase_orchestrator/audit/logger.py
+++ b/src/scpn_phase_orchestrator/audit/logger.py
@@ -46,6 +46,7 @@ class AuditLogger:
         method: str = "euler",
         seed: int | None = None,
         amplitude_mode: bool = False,
+        binding_config: dict[str, object] | None = None,
     ) -> None:
         """Engine configuration record for replay reconstruction."""
         record: dict = {
@@ -58,6 +59,8 @@ class AuditLogger:
             record["seed"] = seed
         if amplitude_mode:
             record["amplitude_mode"] = True
+        if binding_config is not None:
+            record["binding_config"] = binding_config
         self._write_record(record)
 
     def log_step(

--- a/src/scpn_phase_orchestrator/binding/__init__.py
+++ b/src/scpn_phase_orchestrator/binding/__init__.py
@@ -9,6 +9,10 @@
 from __future__ import annotations
 
 from scpn_phase_orchestrator.binding.loader import BindingLoadError, load_binding_spec
+from scpn_phase_orchestrator.binding.resolved import (
+    format_resolved_binding_config,
+    resolved_binding_config,
+)
 from scpn_phase_orchestrator.binding.semantic import SemanticDomainCompiler
 from scpn_phase_orchestrator.binding.types import BindingSpec
 from scpn_phase_orchestrator.binding.validator import validate_binding_spec
@@ -17,6 +21,8 @@ __all__ = [
     "BindingLoadError",
     "BindingSpec",
     "SemanticDomainCompiler",
+    "format_resolved_binding_config",
     "load_binding_spec",
+    "resolved_binding_config",
     "validate_binding_spec",
 ]

--- a/src/scpn_phase_orchestrator/binding/resolved.py
+++ b/src/scpn_phase_orchestrator/binding/resolved.py
@@ -1,0 +1,192 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Commercial license available
+# © Concepts 1996–2026 Miroslav Šotek. All rights reserved.
+# © Code 2020–2026 Miroslav Šotek. All rights reserved.
+# ORCID: 0009-0009-3560-0851
+# Contact: www.anulum.li | protoscience@anulum.li
+# SCPN Phase Orchestrator — Resolved binding configuration summary
+
+from __future__ import annotations
+
+from scpn_phase_orchestrator.binding.types import BindingSpec, resolve_extractor_type
+
+__all__ = ["format_resolved_binding_config", "resolved_binding_config"]
+
+
+def _string_list(value: object) -> list[str]:
+    if isinstance(value, list):
+        return [str(item) for item in value]
+    return []
+
+
+def resolved_binding_config(spec: BindingSpec) -> dict[str, object]:
+    """Build a deterministic, JSON-safe summary of binding runtime choices.
+
+    The summary intentionally exposes structural choices, enabled features, and
+    driver key names only. It does not copy raw driver configuration values into
+    audit metadata because production driver blocks may contain endpoints or
+    deployment-local identifiers.
+    """
+    n_osc = sum(len(layer.oscillator_ids) for layer in spec.layers)
+    control_interval_steps = max(1, round(spec.control_period_s / spec.sample_period_s))
+    family_channels = {
+        name: family.channel
+        for name, family in sorted(spec.oscillator_families.items())
+    }
+    driver_configs = spec.drivers.all_channel_configs()
+    channels = sorted(set(family_channels.values()) | set(driver_configs))
+
+    family_summaries: dict[str, dict[str, object]] = {}
+    for name, family in sorted(spec.oscillator_families.items()):
+        family_summaries[name] = {
+            "channel": family.channel,
+            "extractor_type": family.extractor_type,
+            "resolved_extractor_type": resolve_extractor_type(family.extractor_type),
+            "config_keys": sorted(family.config),
+        }
+
+    layer_summaries: list[dict[str, object]] = []
+    for layer in sorted(spec.layers, key=lambda item: item.index):
+        channel = family_channels.get(layer.family) if layer.family else None
+        layer_summaries.append(
+            {
+                "name": layer.name,
+                "index": layer.index,
+                "family": layer.family,
+                "channel": channel,
+                "oscillator_count": len(layer.oscillator_ids),
+            }
+        )
+
+    channel_summaries: dict[str, dict[str, object]] = {}
+    for channel in channels:
+        family_names = sorted(
+            name
+            for name, family_channel in family_channels.items()
+            if family_channel == channel
+        )
+        channel_layers = [
+            layer
+            for layer in spec.layers
+            if layer.family is not None and layer.family in family_names
+        ]
+        extractors = sorted(
+            {
+                resolve_extractor_type(spec.oscillator_families[name].extractor_type)
+                for name in family_names
+            }
+        )
+        driver_config = driver_configs.get(channel, {})
+        channel_summaries[channel] = {
+            "families": family_names,
+            "extractors": extractors,
+            "driver_configured": bool(driver_config),
+            "driver_keys": sorted(driver_config),
+            "layer_count": len(channel_layers),
+            "oscillator_count": sum(
+                len(layer.oscillator_ids) for layer in channel_layers
+            ),
+        }
+
+    features = {
+        "amplitude": spec.amplitude is not None,
+        "geometry_prior": spec.geometry_prior is not None,
+        "imprint_model": spec.imprint_model is not None,
+        "protocol_net": spec.protocol_net is not None,
+    }
+
+    return {
+        "name": spec.name,
+        "version": spec.version,
+        "safety_tier": spec.safety_tier,
+        "sample_period_s": spec.sample_period_s,
+        "control_period_s": spec.control_period_s,
+        "control_interval_steps": control_interval_steps,
+        "engine_mode": "stuart_landau" if spec.amplitude is not None else "kuramoto",
+        "layer_count": len(spec.layers),
+        "oscillator_count": n_osc,
+        "channels": channel_summaries,
+        "families": family_summaries,
+        "layers": layer_summaries,
+        "unassigned_layer_count": sum(
+            1 for layer in spec.layers if layer.family is None
+        ),
+        "coupling": {
+            "base_strength": spec.coupling.base_strength,
+            "decay_alpha": spec.coupling.decay_alpha,
+            "templates": sorted(spec.coupling.templates),
+        },
+        "objectives": {
+            "good_layers": list(spec.objectives.good_layers),
+            "bad_layers": list(spec.objectives.bad_layers),
+            "good_weight": spec.objectives.good_weight,
+            "bad_weight": spec.objectives.bad_weight,
+        },
+        "boundaries": [
+            {
+                "name": boundary.name,
+                "variable": boundary.variable,
+                "severity": boundary.severity,
+            }
+            for boundary in sorted(spec.boundaries, key=lambda item: item.name)
+        ],
+        "actuators": [
+            {
+                "name": actuator.name,
+                "knob": actuator.knob,
+                "scope": actuator.scope,
+                "limits": list(actuator.limits),
+            }
+            for actuator in sorted(spec.actuators, key=lambda item: item.name)
+        ],
+        "features": features,
+    }
+
+
+def format_resolved_binding_config(summary: dict[str, object]) -> list[str]:
+    """Render a compact, human-readable summary for CLI output."""
+    channels = summary["channels"]
+    assert isinstance(channels, dict)  # nosec B101 — internal summary shape
+    features = summary["features"]
+    assert isinstance(features, dict)  # nosec B101 — internal summary shape
+    enabled_features = sorted(name for name, enabled in features.items() if enabled)
+    feature_text = ", ".join(enabled_features) if enabled_features else "none"
+    channel_names = ", ".join(sorted(str(channel) for channel in channels)) or "none"
+
+    lines = [
+        "Resolved configuration:",
+        (
+            f"  domain: {summary['name']} v{summary['version']} "
+            f"({summary['safety_tier']})"
+        ),
+        (
+            f"  timing: sample={summary['sample_period_s']}s "
+            f"control={summary['control_period_s']}s "
+            f"interval={summary['control_interval_steps']} steps"
+        ),
+        (
+            f"  structure: layers={summary['layer_count']} "
+            f"oscillators={summary['oscillator_count']} channels={channel_names}"
+        ),
+        f"  engine: {summary['engine_mode']} features={feature_text}",
+    ]
+
+    for channel, raw_info in sorted(channels.items(), key=lambda item: str(item[0])):
+        assert isinstance(raw_info, dict)  # nosec B101 — internal summary shape
+        families = _string_list(raw_info.get("families")) or ["none"]
+        extractors = _string_list(raw_info.get("extractors")) or ["none"]
+        driver_keys = _string_list(raw_info.get("driver_keys")) or ["none"]
+        lines.append(
+            f"  channel {channel}: families={','.join(families)} "
+            f"extractors={','.join(extractors)} "
+            f"driver_keys={','.join(driver_keys)} "
+            f"layers={raw_info.get('layer_count', 0)} "
+            f"oscillators={raw_info.get('oscillator_count', 0)}"
+        )
+
+    unassigned = summary.get("unassigned_layer_count", 0)
+    if unassigned:
+        lines.append(
+            f"  note: {unassigned} layer(s) have no explicit oscillator family binding"
+        )
+    return lines

--- a/src/scpn_phase_orchestrator/cli.py
+++ b/src/scpn_phase_orchestrator/cli.py
@@ -17,7 +17,12 @@ import numpy as np
 from scpn_phase_orchestrator.actuation.constraints import ActionProjector
 from scpn_phase_orchestrator.audit.logger import AuditLogger
 from scpn_phase_orchestrator.audit.replay import ReplayEngine
-from scpn_phase_orchestrator.binding import load_binding_spec, validate_binding_spec
+from scpn_phase_orchestrator.binding import (
+    format_resolved_binding_config,
+    load_binding_spec,
+    resolved_binding_config,
+    validate_binding_spec,
+)
 from scpn_phase_orchestrator.coupling.geometry_constraints import (
     GeometryConstraint,
     NonNegativeConstraint,
@@ -73,6 +78,9 @@ def validate(binding_spec: str) -> None:
             click.echo(f"ERROR: {e}", err=True)
         raise SystemExit(1)
     click.echo("Valid")
+    summary = resolved_binding_config(spec)
+    for line in format_resolved_binding_config(summary):
+        click.echo(line)
 
 
 @main.command()
@@ -95,6 +103,9 @@ def run(binding_spec: str, steps: int, audit: str | None, seed: int) -> None:
             "non-research tiers are not yet enforced at runtime",
             err=True,
         )
+    binding_summary = resolved_binding_config(spec)
+    for line in format_resolved_binding_config(binding_summary):
+        click.echo(line)
 
     n_osc = sum(len(layer.oscillator_ids) for layer in spec.layers)
     if n_osc == 0:
@@ -245,6 +256,7 @@ def run(binding_spec: str, steps: int, audit: str | None, seed: int) -> None:
             dt=spec.sample_period_s,
             seed=seed,
             amplitude_mode=amplitude_mode,
+            binding_config=binding_summary,
         )
     try:
         for step_idx in range(steps):

--- a/tests/test_audit_logger.py
+++ b/tests/test_audit_logger.py
@@ -308,6 +308,23 @@ class TestAuditHeader:
         record = json.loads(log_path.read_text().strip())
         assert record["amplitude_mode"] is True
 
+    def test_header_contains_binding_config_when_provided(self, tmp_path):
+        log_path = tmp_path / "audit.jsonl"
+        binding_config = {
+            "name": "demo",
+            "engine_mode": "kuramoto",
+            "channels": {"P": {"driver_keys": ["frequency"]}},
+        }
+        with AuditLogger(log_path) as logger:
+            logger.log_header(
+                n_oscillators=4,
+                dt=0.005,
+                binding_config=binding_config,
+            )
+
+        record = json.loads(log_path.read_text().strip())
+        assert record["binding_config"] == binding_config
+
     def test_header_without_seed_omits_field(self, tmp_path):
         """Optional fields must be absent, not null, when not provided."""
         log_path = tmp_path / "audit.jsonl"

--- a/tests/test_binding_resolved.py
+++ b/tests/test_binding_resolved.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Commercial license available
+# © Concepts 1996–2026 Miroslav Šotek. All rights reserved.
+# © Code 2020–2026 Miroslav Šotek. All rights reserved.
+# ORCID: 0009-0009-3560-0851
+# Contact: www.anulum.li | protoscience@anulum.li
+# SCPN Phase Orchestrator — Resolved binding configuration tests
+
+from __future__ import annotations
+
+import yaml
+
+from scpn_phase_orchestrator.binding import (
+    format_resolved_binding_config,
+    load_binding_spec,
+    resolved_binding_config,
+)
+
+
+def _write_spec(tmp_path, spec: dict) -> str:
+    path = tmp_path / "binding_spec.yaml"
+    path.write_text(yaml.dump(spec), encoding="utf-8")
+    return str(path)
+
+
+def test_resolved_binding_config_summarises_runtime_choices(tmp_path):
+    path = _write_spec(
+        tmp_path,
+        {
+            "name": "resolved-test",
+            "version": "1.0.0",
+            "safety_tier": "research",
+            "sample_period_s": 0.01,
+            "control_period_s": 0.1,
+            "layers": [
+                {
+                    "name": "plant",
+                    "index": 0,
+                    "oscillator_ids": ["p0", "p1"],
+                    "family": "phys",
+                },
+                {"name": "events", "index": 1, "oscillator_ids": ["e0"]},
+            ],
+            "oscillator_families": {
+                "phys": {
+                    "channel": "P",
+                    "extractor_type": "physical",
+                    "config": {"window": 16},
+                },
+            },
+            "coupling": {
+                "base_strength": 0.45,
+                "decay_alpha": 0.3,
+                "templates": {"local": "nearest"},
+            },
+            "drivers": {
+                "physical": {"frequency": 1.0, "zeta": 0.2},
+                "informational": {},
+                "symbolic": {},
+            },
+            "objectives": {"good_layers": [0], "bad_layers": [1]},
+            "boundaries": [],
+            "actuators": [],
+        },
+    )
+
+    summary = resolved_binding_config(load_binding_spec(path))
+
+    assert summary["engine_mode"] == "kuramoto"
+    assert summary["control_interval_steps"] == 10
+    assert summary["oscillator_count"] == 3
+    assert summary["unassigned_layer_count"] == 1
+    channels = summary["channels"]
+    assert channels["P"]["families"] == ["phys"]
+    assert channels["P"]["extractors"] == ["hilbert"]
+    assert channels["P"]["driver_keys"] == ["frequency", "zeta"]
+    assert channels["P"]["oscillator_count"] == 2
+
+
+def test_resolved_binding_config_includes_named_channels(tmp_path):
+    path = _write_spec(
+        tmp_path,
+        {
+            "name": "resolved-extra-test",
+            "version": "1.0.0",
+            "safety_tier": "research",
+            "sample_period_s": 0.02,
+            "control_period_s": 0.1,
+            "layers": [
+                {
+                    "name": "operator",
+                    "index": 0,
+                    "oscillator_ids": ["h0", "h1"],
+                    "family": "human",
+                }
+            ],
+            "oscillator_families": {
+                "human": {"channel": "H", "extractor_type": "event", "config": {}},
+            },
+            "coupling": {"base_strength": 0.2, "decay_alpha": 0.1, "templates": {}},
+            "drivers": {
+                "physical": {},
+                "informational": {},
+                "symbolic": {},
+                "H": {"cadence_hz": 2.0},
+            },
+            "objectives": {"good_layers": [0], "bad_layers": []},
+            "boundaries": [],
+            "actuators": [],
+        },
+    )
+
+    summary = resolved_binding_config(load_binding_spec(path))
+    lines = format_resolved_binding_config(summary)
+
+    assert "H" in summary["channels"]
+    assert summary["channels"]["H"]["driver_keys"] == ["cadence_hz"]
+    assert any("channel H:" in line for line in lines)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -93,6 +93,8 @@ def test_validate_valid(runner, valid_spec_path):
     result = runner.invoke(main, ["validate", valid_spec_path])
     assert result.exit_code == 0
     assert "Valid" in result.output
+    assert "Resolved configuration:" in result.output
+    assert "engine: kuramoto" in result.output
 
 
 def test_validate_invalid(runner, invalid_spec_path):
@@ -104,8 +106,22 @@ def test_validate_invalid(runner, invalid_spec_path):
 def test_run_simulation(runner, valid_spec_path):
     result = runner.invoke(main, ["run", valid_spec_path, "--steps", "10"])
     assert result.exit_code == 0
+    assert "Resolved configuration:" in result.output
     assert "R_good" in result.output
     assert "R_bad" in result.output
+
+
+def test_run_audit_header_contains_binding_config(runner, valid_spec_path, tmp_path):
+    audit_path = tmp_path / "audit.jsonl"
+    result = runner.invoke(
+        main,
+        ["run", valid_spec_path, "--steps", "2", "--audit", str(audit_path)],
+    )
+    assert result.exit_code == 0
+    header = json.loads(audit_path.read_text(encoding="utf-8").splitlines()[0])
+    assert header["binding_config"]["name"] == "cli-test"
+    assert header["binding_config"]["engine_mode"] == "kuramoto"
+    assert "P" in header["binding_config"]["channels"]
 
 
 def test_run_invalid_spec(runner, invalid_spec_path):


### PR DESCRIPTION
## Summary
- add a deterministic resolved binding summary for CLI validation/run output
- include the same compact summary in audit headers without raw driver values
- document the YAML-to-runtime pipeline in the MkDocs site

## Local validation
- .venv-linux/bin/ruff check src/scpn_phase_orchestrator/binding/resolved.py src/scpn_phase_orchestrator/binding/__init__.py src/scpn_phase_orchestrator/cli.py src/scpn_phase_orchestrator/audit/logger.py tests/test_binding_resolved.py tests/test_cli.py tests/test_audit_logger.py
- .venv-linux/bin/python -m pytest tests/test_binding_resolved.py tests/test_cli.py tests/test_audit_logger.py
- .venv-linux/bin/python -m mypy src/scpn_phase_orchestrator/binding/resolved.py src/scpn_phase_orchestrator/audit/logger.py
- .venv-linux/bin/python -m mkdocs build --site-dir /tmp/spo-mkdocs-check

## Notes
- Strict MkDocs build remains blocked by pre-existing docs warnings for unnaved pages and duplicate autorefs.
- Full pytest/coverage gate is delegated to remote CI under the approved local-hardware override.