### PR TITLE
Harden binding loader fuzz boundary

### DIFF
--- a/src/scpn_phase_orchestrator/binding/loader.py
+++ b/src/scpn_phase_orchestrator/binding/loader.py
@@ -46,6 +46,90 @@ def _require(data: dict, key: str, context: str = "") -> Any:
         raise BindingLoadError(f"missing required key {key!r}{loc}") from None
 
 
+def _expected(kind: str, context: str, value: object) -> BindingLoadError:
+    return BindingLoadError(f"expected {kind} in {context}, got {type(value).__name__}")
+
+
+def _require_mapping(value: object, context: str) -> dict:
+    if not isinstance(value, dict):
+        raise _expected("mapping", context, value)
+    return value
+
+
+def _optional_mapping(value: object, context: str) -> dict:
+    if value is None:
+        return {}
+    return _require_mapping(value, context)
+
+
+def _require_list(value: object, context: str) -> list:
+    if not isinstance(value, list):
+        raise _expected("list", context, value)
+    return value
+
+
+def _optional_list(value: object, context: str) -> list:
+    if value is None:
+        return []
+    return _require_list(value, context)
+
+
+def _require_str(value: object, context: str) -> str:
+    if not isinstance(value, str):
+        raise _expected("string", context, value)
+    return value
+
+
+def _require_int(value: object, context: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise _expected("integer", context, value)
+    return value
+
+
+def _require_number(value: object, context: str) -> float:
+    if not isinstance(value, int | float) or isinstance(value, bool):
+        raise _expected("number", context, value)
+    return float(value)
+
+
+def _optional_number(value: object, context: str) -> float | None:
+    if value is None:
+        return None
+    return _require_number(value, context)
+
+
+def _optional_str(value: object, context: str) -> str | None:
+    if value is None:
+        return None
+    return _require_str(value, context)
+
+
+def _optional_str_list(value: object, context: str) -> list[str]:
+    items = _optional_list(value, context)
+    return [_require_str(item, f"{context}[]") for item in items]
+
+
+def _optional_number_list(value: object, context: str) -> list[float] | None:
+    if value is None:
+        return None
+    items = _require_list(value, context)
+    return [_require_number(item, f"{context}[]") for item in items]
+
+
+def _require_number_list(value: object, context: str) -> list[float]:
+    items = _require_list(value, context)
+    return [_require_number(item, f"{context}[]") for item in items]
+
+
+def _require_number_pair(value: object, context: str) -> tuple[float, float]:
+    items = _require_number_list(value, context)
+    if len(items) != 2:
+        raise BindingLoadError(
+            f"expected two numbers in {context}, got {len(items)} item(s)"
+        )
+    return (items[0], items[1])
+
+
 def load_binding_spec(path: str | Path) -> BindingSpec:
     """Load a BindingSpec from a YAML or JSON file."""
     path = Path(path)
@@ -77,131 +161,237 @@ def load_binding_spec(path: str | Path) -> BindingSpec:
             f"expected mapping at top level, got {type(data).__name__}"
         )
 
-    layers = [
-        HierarchyLayer(
-            name=_require(lay, "name", "layers[]"),
-            index=_require(lay, "index", "layers[]"),
-            oscillator_ids=lay.get("oscillator_ids", []),
-            omegas=lay.get("omegas"),
-            family=lay.get("family"),
+    layers_data = _require_list(_require(data, "layers", "root"), "layers")
+    layers = []
+    for i, raw_layer in enumerate(layers_data):
+        lay = _require_mapping(raw_layer, f"layers[{i}]")
+        layers.append(
+            HierarchyLayer(
+                name=_require_str(_require(lay, "name", "layers[]"), "layers[].name"),
+                index=_require_int(
+                    _require(lay, "index", "layers[]"), "layers[].index"
+                ),
+                oscillator_ids=_optional_str_list(
+                    lay.get("oscillator_ids"), "layers[].oscillator_ids"
+                ),
+                omegas=_optional_number_list(lay.get("omegas"), "layers[].omegas"),
+                family=_optional_str(lay.get("family"), "layers[].family"),
+            )
         )
-        for lay in _require(data, "layers", "root")
-    ]
 
-    osc_families = {
-        k: OscillatorFamily(
-            channel=_require(v, "channel", f"oscillator_families.{k}"),
-            extractor_type=resolve_extractor_type(
-                _require(v, "extractor_type", f"oscillator_families.{k}")
+    families_data = _require_mapping(
+        _require(data, "oscillator_families", "root"), "oscillator_families"
+    )
+    osc_families = {}
+    for key, raw_family in families_data.items():
+        family_name = _require_str(key, "oscillator_families key")
+        family_data = _require_mapping(raw_family, f"oscillator_families.{family_name}")
+        extractor_type = _require_str(
+            _require(
+                family_data, "extractor_type", f"oscillator_families.{family_name}"
             ),
-            config=v.get("config", {}),
+            f"oscillator_families.{family_name}.extractor_type",
         )
-        for k, v in _require(data, "oscillator_families", "root").items()
-    }
+        osc_families[family_name] = OscillatorFamily(
+            channel=_require_str(
+                _require(family_data, "channel", f"oscillator_families.{family_name}"),
+                f"oscillator_families.{family_name}.channel",
+            ),
+            extractor_type=resolve_extractor_type(extractor_type),
+            config=_optional_mapping(
+                family_data.get("config"), f"oscillator_families.{family_name}.config"
+            ),
+        )
 
-    coupling_data = _require(data, "coupling", "root")
+    coupling_data = _require_mapping(_require(data, "coupling", "root"), "coupling")
     coupling = CouplingSpec(
-        base_strength=_require(coupling_data, "base_strength", "coupling"),
-        decay_alpha=_require(coupling_data, "decay_alpha", "coupling"),
-        templates=coupling_data.get("templates", {}),
+        base_strength=_require_number(
+            _require(coupling_data, "base_strength", "coupling"),
+            "coupling.base_strength",
+        ),
+        decay_alpha=_require_number(
+            _require(coupling_data, "decay_alpha", "coupling"),
+            "coupling.decay_alpha",
+        ),
+        templates=_optional_mapping(
+            coupling_data.get("templates"), "coupling.templates"
+        ),
     )
 
-    drivers_data = _require(data, "drivers", "root")
+    drivers_data = _require_mapping(_require(data, "drivers", "root"), "drivers")
     standard_driver_keys = {"physical", "informational", "symbolic"}
     extra_drivers = {
         key: value
         for key, value in drivers_data.items()
-        if key not in standard_driver_keys and isinstance(value, dict)
+        if isinstance(key, str)
+        and key not in standard_driver_keys
+        and isinstance(value, dict)
     }
     drivers = DriverSpec(
-        physical=drivers_data.get("physical", {}),
-        informational=drivers_data.get("informational", {}),
-        symbolic=drivers_data.get("symbolic", {}),
+        physical=_optional_mapping(drivers_data.get("physical"), "drivers.physical"),
+        informational=_optional_mapping(
+            drivers_data.get("informational"), "drivers.informational"
+        ),
+        symbolic=_optional_mapping(drivers_data.get("symbolic"), "drivers.symbolic"),
         extra=extra_drivers,
     )
 
-    obj = _require(data, "objectives", "root")
+    obj = _require_mapping(_require(data, "objectives", "root"), "objectives")
     objectives = ObjectivePartition(
-        good_layers=_require(obj, "good_layers", "objectives"),
-        bad_layers=_require(obj, "bad_layers", "objectives"),
-        good_weight=obj.get("good_weight", 1.0),
-        bad_weight=obj.get("bad_weight", 1.0),
+        good_layers=_require_list(
+            _require(obj, "good_layers", "objectives"), "objectives.good_layers"
+        ),
+        bad_layers=_require_list(
+            _require(obj, "bad_layers", "objectives"), "objectives.bad_layers"
+        ),
+        good_weight=_require_number(
+            obj.get("good_weight", 1.0), "objectives.good_weight"
+        ),
+        bad_weight=_require_number(obj.get("bad_weight", 1.0), "objectives.bad_weight"),
     )
 
-    boundaries = [
-        BoundaryDef(
-            name=_require(b, "name", "boundaries[]"),
-            variable=_require(b, "variable", "boundaries[]"),
-            lower=b.get("lower"),
-            upper=b.get("upper"),
-            severity=_require(b, "severity", "boundaries[]"),
+    boundaries = []
+    for i, raw_boundary in enumerate(
+        _optional_list(data.get("boundaries"), "boundaries")
+    ):
+        b = _require_mapping(raw_boundary, f"boundaries[{i}]")
+        boundaries.append(
+            BoundaryDef(
+                name=_require_str(
+                    _require(b, "name", "boundaries[]"), "boundaries[].name"
+                ),
+                variable=_require_str(
+                    _require(b, "variable", "boundaries[]"), "boundaries[].variable"
+                ),
+                lower=_optional_number(b.get("lower"), "boundaries[].lower"),
+                upper=_optional_number(b.get("upper"), "boundaries[].upper"),
+                severity=_require_str(
+                    _require(b, "severity", "boundaries[]"), "boundaries[].severity"
+                ),
+            )
         )
-        for b in data.get("boundaries", [])
-    ]
 
-    actuators = [
-        ActuatorMapping(
-            name=_require(a, "name", "actuators[]"),
-            knob=_require(a, "knob", "actuators[]"),
-            scope=_require(a, "scope", "actuators[]"),
-            limits=tuple(_require(a, "limits", "actuators[]")),
+    actuators = []
+    for i, raw_actuator in enumerate(
+        _optional_list(data.get("actuators"), "actuators")
+    ):
+        a = _require_mapping(raw_actuator, f"actuators[{i}]")
+        actuators.append(
+            ActuatorMapping(
+                name=_require_str(
+                    _require(a, "name", "actuators[]"), "actuators[].name"
+                ),
+                knob=_require_str(
+                    _require(a, "knob", "actuators[]"), "actuators[].knob"
+                ),
+                scope=_require_str(
+                    _require(a, "scope", "actuators[]"), "actuators[].scope"
+                ),
+                limits=_require_number_pair(
+                    _require(a, "limits", "actuators[]"), "actuators[].limits"
+                ),
+            )
         )
-        for a in data.get("actuators", [])
-    ]
 
     imprint_data = data.get("imprint_model") or data.get("imprint")
     imprint = None
     if imprint_data:
+        imprint_map = _require_mapping(imprint_data, "imprint_model")
         imprint = ImprintSpec(
-            decay_rate=_require(imprint_data, "decay_rate", "imprint_model"),
-            saturation=_require(imprint_data, "saturation", "imprint_model"),
-            modulates=imprint_data.get("modulates", []),
+            decay_rate=_require_number(
+                _require(imprint_map, "decay_rate", "imprint_model"),
+                "imprint_model.decay_rate",
+            ),
+            saturation=_require_number(
+                _require(imprint_map, "saturation", "imprint_model"),
+                "imprint_model.saturation",
+            ),
+            modulates=_optional_list(
+                imprint_map.get("modulates"), "imprint_model.modulates"
+            ),
         )
 
     geo_data = data.get("geometry_prior")
     geometry = None
     if geo_data:
+        geo_map = _require_mapping(geo_data, "geometry_prior")
         geometry = GeometrySpec(
-            constraint_type=_require(geo_data, "constraint_type", "geometry_prior"),
-            params=geo_data.get("params", {}),
+            constraint_type=_require_str(
+                _require(geo_map, "constraint_type", "geometry_prior"),
+                "geometry_prior.constraint_type",
+            ),
+            params=_optional_mapping(geo_map.get("params"), "geometry_prior.params"),
         )
 
     pnet_data = data.get("protocol_net")
     protocol_net = None
     if pnet_data:
+        pnet_map = _require_mapping(pnet_data, "protocol_net")
         pnet_transitions = []
-        for t in _require(pnet_data, "transitions", "protocol_net"):
+        for i, raw_transition in enumerate(
+            _require_list(
+                _require(pnet_map, "transitions", "protocol_net"),
+                "protocol_net.transitions",
+            )
+        ):
+            t = _require_mapping(raw_transition, f"protocol_net.transitions[{i}]")
             pnet_transitions.append(
                 ProtocolTransitionSpec(
-                    name=_require(t, "name", "protocol_net.transitions[]"),
-                    inputs=t.get("inputs", []),
-                    outputs=t.get("outputs", []),
+                    name=_require_str(
+                        _require(t, "name", "protocol_net.transitions[]"),
+                        "protocol_net.transitions[].name",
+                    ),
+                    inputs=_optional_list(
+                        t.get("inputs"), "protocol_net.transitions[].inputs"
+                    ),
+                    outputs=_optional_list(
+                        t.get("outputs"), "protocol_net.transitions[].outputs"
+                    ),
                     guard=t.get("guard"),
                 )
             )
         protocol_net = ProtocolNetSpec(
-            places=_require(pnet_data, "places", "protocol_net"),
-            initial=_require(pnet_data, "initial", "protocol_net"),
-            place_regime=pnet_data.get("place_regime", {}),
+            places=_require_list(
+                _require(pnet_map, "places", "protocol_net"), "protocol_net.places"
+            ),
+            initial=_require_mapping(
+                _require(pnet_map, "initial", "protocol_net"), "protocol_net.initial"
+            ),
+            place_regime=_optional_mapping(
+                pnet_map.get("place_regime"), "protocol_net.place_regime"
+            ),
             transitions=pnet_transitions,
         )
 
     amp_data = data.get("amplitude")
     amplitude = None
     if amp_data:
+        amp_map = _require_mapping(amp_data, "amplitude")
         amplitude = AmplitudeSpec(
-            mu=_require(amp_data, "mu", "amplitude"),
-            epsilon=_require(amp_data, "epsilon", "amplitude"),
-            amp_coupling_strength=amp_data.get("amp_coupling_strength", 0.0),
-            amp_coupling_decay=amp_data.get("amp_coupling_decay", 0.3),
+            mu=_require_number(_require(amp_map, "mu", "amplitude"), "amplitude.mu"),
+            epsilon=_require_number(
+                _require(amp_map, "epsilon", "amplitude"), "amplitude.epsilon"
+            ),
+            amp_coupling_strength=_require_number(
+                amp_map.get("amp_coupling_strength", 0.0),
+                "amplitude.amp_coupling_strength",
+            ),
+            amp_coupling_decay=_require_number(
+                amp_map.get("amp_coupling_decay", 0.3),
+                "amplitude.amp_coupling_decay",
+            ),
         )
 
     return BindingSpec(
-        name=_require(data, "name", "root"),
-        version=_require(data, "version", "root"),
-        safety_tier=_require(data, "safety_tier", "root"),
-        sample_period_s=_require(data, "sample_period_s", "root"),
-        control_period_s=_require(data, "control_period_s", "root"),
+        name=_require_str(_require(data, "name", "root"), "name"),
+        version=_require_str(_require(data, "version", "root"), "version"),
+        safety_tier=_require_str(_require(data, "safety_tier", "root"), "safety_tier"),
+        sample_period_s=_require_number(
+            _require(data, "sample_period_s", "root"), "sample_period_s"
+        ),
+        control_period_s=_require_number(
+            _require(data, "control_period_s", "root"), "control_period_s"
+        ),
         layers=layers,
         oscillator_families=osc_families,
         coupling=coupling,

--- a/tests/test_binding_loader_fuzz.py
+++ b/tests/test_binding_loader_fuzz.py
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Commercial license available
+# © Concepts 1996–2026 Miroslav Šotek. All rights reserved.
+# © Code 2020–2026 Miroslav Šotek. All rights reserved.
+# ORCID: 0009-0009-3560-0851
+# Contact: www.anulum.li | protoscience@anulum.li
+# SCPN Phase Orchestrator — Binding loader fuzz tests
+
+from __future__ import annotations
+
+from typing import Any
+
+import yaml
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from scpn_phase_orchestrator.binding import validate_binding_spec
+from scpn_phase_orchestrator.binding.loader import BindingLoadError, load_binding_spec
+
+_SCALAR = (
+    st.none()
+    | st.booleans()
+    | st.integers(min_value=-10, max_value=10)
+    | st.floats(
+        min_value=-10.0,
+        max_value=10.0,
+        allow_nan=False,
+        allow_infinity=False,
+    )
+    | st.text(min_size=0, max_size=12)
+)
+
+_YAML_VALUE = st.recursive(
+    _SCALAR,
+    lambda children: (
+        st.lists(children, max_size=4)
+        | st.dictionaries(st.text(min_size=0, max_size=12), children, max_size=4)
+    ),
+    max_leaves=20,
+)
+
+
+def _write_yaml(tmp_path, payload: Any) -> str:
+    path = tmp_path / "fuzz_binding.yaml"
+    path.write_text(yaml.safe_dump(payload), encoding="utf-8")
+    return str(path)
+
+
+def _assert_load_or_controlled_error(tmp_path, payload: Any) -> None:
+    path = _write_yaml(tmp_path, payload)
+    try:
+        spec = load_binding_spec(path)
+    except BindingLoadError as exc:
+        message = str(exc)
+        assert str(tmp_path) not in message
+        assert "fuzz_binding.yaml" not in message or "/" not in message
+        return
+
+    errors = validate_binding_spec(spec)
+    assert isinstance(errors, list)
+    assert all(isinstance(error, str) for error in errors)
+
+
+@given(_YAML_VALUE)
+@settings(
+    max_examples=100,
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture, HealthCheck.too_slow],
+)
+def test_random_yaml_payloads_fail_as_binding_load_errors(tmp_path, payload):
+    _assert_load_or_controlled_error(tmp_path, payload)
+
+
+@given(
+    name=_YAML_VALUE,
+    version=_YAML_VALUE,
+    safety_tier=_YAML_VALUE,
+    sample_period_s=_YAML_VALUE,
+    control_period_s=_YAML_VALUE,
+    layers=_YAML_VALUE,
+    oscillator_families=_YAML_VALUE,
+    coupling=_YAML_VALUE,
+    drivers=_YAML_VALUE,
+    objectives=_YAML_VALUE,
+    boundaries=_YAML_VALUE,
+    actuators=_YAML_VALUE,
+    imprint_model=_YAML_VALUE,
+    geometry_prior=_YAML_VALUE,
+    protocol_net=_YAML_VALUE,
+    amplitude=_YAML_VALUE,
+)
+@settings(
+    max_examples=100,
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture, HealthCheck.too_slow],
+)
+def test_binding_shaped_yaml_payloads_do_not_escape_loader_boundary(
+    tmp_path,
+    name,
+    version,
+    safety_tier,
+    sample_period_s,
+    control_period_s,
+    layers,
+    oscillator_families,
+    coupling,
+    drivers,
+    objectives,
+    boundaries,
+    actuators,
+    imprint_model,
+    geometry_prior,
+    protocol_net,
+    amplitude,
+):
+    payload = {
+        "name": name,
+        "version": version,
+        "safety_tier": safety_tier,
+        "sample_period_s": sample_period_s,
+        "control_period_s": control_period_s,
+        "layers": layers,
+        "oscillator_families": oscillator_families,
+        "coupling": coupling,
+        "drivers": drivers,
+        "objectives": objectives,
+        "boundaries": boundaries,
+        "actuators": actuators,
+        "imprint_model": imprint_model,
+        "geometry_prior": geometry_prior,
+        "protocol_net": protocol_net,
+        "amplitude": amplitude,
+    }
+    _assert_load_or_controlled_error(tmp_path, payload)
+
+
+# Pipeline wiring: fuzzed YAML enters at the same load_binding_spec()
+# boundary used by CLI validation and simulation startup.


### PR DESCRIPTION
## Summary
- reject malformed nested binding YAML/JSON shapes with controlled BindingLoadError responses
- add Hypothesis fuzz coverage for random payloads and binding-shaped malformed payloads
- verify all shipped domainpack binding specs still load and validate

## Local validation
- .venv-linux/bin/ruff check src/scpn_phase_orchestrator/binding/loader.py tests/test_binding_loader_fuzz.py
- .venv-linux/bin/python -m pytest tests/test_loader_errors.py tests/test_binding_loader_fuzz.py
- .venv-linux/bin/python -m pytest tests/test_cli.py tests/test_binding_validator.py tests/test_loader_errors.py tests/test_binding_loader_fuzz.py
- .venv-linux/bin/python -m mypy src/scpn_phase_orchestrator/binding/loader.py
- .venv-linux/bin/python -c "...load and validate all domainpacks..."

## Notes
- Full pytest/coverage is delegated to remote CI under the approved local-hardware override.