### PR TITLE
Add QueueWaves production template

### DIFF
--- a/docs/guide/queuewaves.md
+++ b/docs/guide/queuewaves.md
@@ -76,6 +76,12 @@ security:
   rate_limit_per_minute: 120
 ```
 
+The production-ready template lives at
+`domainpacks/queuewaves/queuewaves.production.yaml`. It sets
+`security.mode: production`, `api_key_env: QUEUEWAVES_API_KEY`, and a positive
+request rate limit, so deployments do not need to remember those fields from
+scratch.
+
 ### Key Fields
 
 | Field | Default | Meaning |
@@ -108,7 +114,7 @@ security:
 
 ```bash
 export QUEUEWAVES_API_KEY="$(openssl rand -hex 32)"
-spo queuewaves serve --config queuewaves.yaml --host 0.0.0.0 --port 8080
+spo queuewaves serve --config domainpacks/queuewaves/queuewaves.production.yaml
 ```
 
 Starts a FastAPI application. Scrapes Prometheus on each interval, runs the
@@ -221,11 +227,12 @@ It connects to `/ws/stream` for live updates and renders:
 ## Production Deployment
 
 ```bash
-uvicorn scpn_phase_orchestrator.apps.queuewaves.server:create_app \
-    --factory --host 0.0.0.0 --port 8080 --workers 1
+export QUEUEWAVES_API_KEY="$(openssl rand -hex 32)"
+spo queuewaves serve --config domainpacks/queuewaves/queuewaves.production.yaml
 ```
 
 QueueWaves is single-process (shared pipeline state). Run behind nginx or
-Traefik for TLS termination, set `security.mode: production`, and provide
-`QUEUEWAVES_API_KEY` before binding to non-loopback interfaces. For multiple
-clusters, run one QueueWaves instance per Prometheus source.
+Traefik for TLS termination. The production template already sets
+`security.mode: production`; the server refuses to start unless
+`QUEUEWAVES_API_KEY` is present. For multiple clusters, run one QueueWaves
+instance per Prometheus source.

--- a/domainpacks/queuewaves/README.md
+++ b/domainpacks/queuewaves/README.md
@@ -40,3 +40,15 @@ pressure accumulate and modulate coupling, representing gradual system decay.
 
 200 steps: steady state -> traffic spike (2x load) -> retry storm (micro
 sync) -> circuit breaker -> recovery.
+
+## Production Template
+
+`queuewaves.production.yaml` is the production-safe service template. It binds
+the server for container or reverse-proxy deployment, sets
+`security.mode: production`, requires the `QUEUEWAVES_API_KEY` environment
+variable, and enables request rate limiting.
+
+```bash
+export QUEUEWAVES_API_KEY="$(openssl rand -hex 32)"
+spo queuewaves serve --config domainpacks/queuewaves/queuewaves.production.yaml
+```

--- a/domainpacks/queuewaves/queuewaves.production.yaml
+++ b/domainpacks/queuewaves/queuewaves.production.yaml
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Commercial license available
+# © Concepts 1996–2026 Miroslav Šotek. All rights reserved.
+# © Code 2020–2026 Miroslav Šotek. All rights reserved.
+# ORCID: 0009-0009-3560-0851
+# Contact: www.anulum.li | protoscience@anulum.li
+# SCPN Phase Orchestrator — QueueWaves production configuration template
+
+prometheus_url: "http://prometheus:9090"
+scrape_interval_s: 15.0
+buffer_length: 64
+
+services:
+  - name: order-api-errors
+    promql: "rate(http_requests_total{service='order-api',code=~'5..'}[1m])"
+    layer: micro
+    channel: P
+  - name: payment-errors
+    promql: "rate(http_requests_total{service='payment-svc',code=~'5..'}[1m])"
+    layer: micro
+    channel: P
+  - name: gateway-p99
+    promql: "histogram_quantile(0.99, rate(http_request_duration_seconds_bucket{service='gateway'}[5m]))"
+    layer: meso
+    channel: P
+  - name: total-throughput
+    promql: "sum(rate(http_requests_total[5m]))"
+    layer: macro
+    channel: P
+
+thresholds:
+  r_bad_warn: 0.50
+  r_bad_critical: 0.70
+  plv_cascade: 0.85
+  imprint_chronic: 1.5
+  cooldown_seconds: 300.0
+
+coupling:
+  strength: 0.50
+  decay: 0.25
+
+alert_sinks:
+  - url: "https://ops.example.com/queuewaves-alert"
+    format: generic
+
+server:
+  host: "0.0.0.0"
+  port: 8080
+
+security:
+  mode: production
+  api_key_env: QUEUEWAVES_API_KEY
+  rate_limit_per_minute: 120

--- a/tests/apps/queuewaves/test_config.py
+++ b/tests/apps/queuewaves/test_config.py
@@ -140,6 +140,19 @@ def test_load_config_defaults(tmp_path: Path) -> None:
     assert cfg.security.rate_limit_per_minute == 120
 
 
+def test_production_template_requires_auth_and_rate_limit() -> None:
+    template = Path("domainpacks/queuewaves/queuewaves.production.yaml")
+
+    cfg = load_config(template)
+
+    assert cfg.security.mode == "production"
+    assert cfg.security.api_key_env == "QUEUEWAVES_API_KEY"
+    assert cfg.security.rate_limit_per_minute > 0
+    assert cfg.server.host == "0.0.0.0"
+    assert cfg.services
+    assert cfg.alert_sinks
+
+
 def test_load_config_normalises_numeric_scalars(tmp_path: Path) -> None:
     yaml_text = textwrap.dedent("""\
         prometheus_url: "http://prom:9090"

--- a/tests/apps/queuewaves/test_server.py
+++ b/tests/apps/queuewaves/test_server.py
@@ -8,6 +8,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from scpn_phase_orchestrator.apps.queuewaves.config import (
@@ -150,3 +152,19 @@ def test_production_rate_limits_requests(
 
     assert first.status_code == 200
     assert second.status_code == 429
+
+
+def test_production_template_server_requires_request_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from scpn_phase_orchestrator.apps.queuewaves.config import load_config
+
+    cfg = load_config(Path("domainpacks/queuewaves/queuewaves.production.yaml"))
+    monkeypatch.setenv("QUEUEWAVES_API_KEY", "template-key")
+    client = TestClient(create_app(cfg))
+
+    missing = client.get("/api/v1/health")
+    present = client.get("/api/v1/health", headers={"X-API-Key": "template-key"})
+
+    assert missing.status_code == 401
+    assert present.status_code == 200


### PR DESCRIPTION
Summary: adds a QueueWaves production configuration template with API-key auth and rate limiting, updates docs to use it for production deployments, and adds tests proving the production template enforces request authentication. Local validation: ruff check on QueueWaves tests, pytest tests/apps/queuewaves/test_config.py tests/apps/queuewaves/test_server.py, mypy on QueueWaves config/server, mkdocs build, staged diff check. Full pytest/coverage delegated to remote CI under the temporary hardware override rule.