### PR TITLE
Generalize QueueWaves service channels

### DIFF
--- a/docs/guide/queuewaves.md
+++ b/docs/guide/queuewaves.md
@@ -48,6 +48,11 @@ services:
     promql: "sum(rate(http_requests_total[5m]))"
     layer: macro
     channel: P
+  - name: retry-budget
+    promql: "retry_budget_remaining"
+    layer: macro
+    channel: RetryBudget
+    extractor_type: event
 
 thresholds:
   r_bad_warn: 0.50
@@ -83,6 +88,8 @@ security:
 | `prometheus_url` | required | Prometheus base URL |
 | `scrape_interval_s` | 15.0 | Seconds between scrape cycles |
 | `buffer_length` | 64 | Rolling buffer length per service |
+| `services[].channel` | P | Binding channel ID. `P`, `I`, and `S` have default extractors; named channels are allowed. |
+| `services[].extractor_type` | channel default | Required for named channels; accepts the normal binding extractor names and aliases. |
 | `thresholds.r_bad_warn` | 0.50 | R_bad warning threshold |
 | `thresholds.r_bad_critical` | 0.70 | R_bad critical threshold |
 | `thresholds.plv_cascade` | 0.85 | PLV cascade propagation threshold |

--- a/src/scpn_phase_orchestrator/apps/queuewaves/config.py
+++ b/src/scpn_phase_orchestrator/apps/queuewaves/config.py
@@ -16,6 +16,7 @@ from urllib.parse import urlparse
 import yaml
 
 from scpn_phase_orchestrator.binding.types import (
+    VALID_EXTRACTORS,
     ActuatorMapping,
     BindingSpec,
     BoundaryDef,
@@ -24,6 +25,8 @@ from scpn_phase_orchestrator.binding.types import (
     HierarchyLayer,
     ObjectivePartition,
     OscillatorFamily,
+    is_valid_channel_id,
+    resolve_extractor_type,
 )
 
 __all__ = [
@@ -36,7 +39,7 @@ __all__ = [
 ]
 
 _LAYER_ORDER = {"micro": 0, "meso": 1, "macro": 2}
-_VALID_CHANNELS = frozenset({"P", "I"})
+_STANDARD_CHANNEL_EXTRACTORS = {"P": "hilbert", "I": "event", "S": "ring"}
 _VALID_ALERT_FORMATS = frozenset({"generic", "slack"})
 _VALID_SECURITY_MODES = frozenset({"development", "production"})
 
@@ -86,12 +89,13 @@ def _require_http_url(value: str, field_name: str) -> str:
 
 @dataclass(frozen=True)
 class ServiceDef:
-    """A monitored service: name, PromQL query, hierarchy layer, and channel type."""
+    """A monitored service: name, PromQL query, hierarchy layer, and channel."""
 
     name: str
     promql: str
     layer: str  # micro, meso, macro
-    channel: str = "P"  # P(hysical) or I(nformational)
+    channel: str = "P"
+    extractor_type: str | None = None
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "name", _require_non_empty(self.name, "service.name"))
@@ -100,8 +104,20 @@ class ServiceDef:
         )
         if self.layer not in _LAYER_ORDER:
             raise ValueError("service.layer must be micro, meso, or macro")
-        if self.channel not in _VALID_CHANNELS:
-            raise ValueError("service.channel must be P or I")
+        if not is_valid_channel_id(self.channel):
+            raise ValueError("service.channel must match [A-Za-z][A-Za-z0-9_-]{0,63}")
+        extractor_type = self.extractor_type
+        if extractor_type is None:
+            extractor_type = _STANDARD_CHANNEL_EXTRACTORS.get(self.channel)
+            if extractor_type is None:
+                raise ValueError(
+                    "service.extractor_type is required for named service channels"
+                )
+        else:
+            extractor_type = resolve_extractor_type(extractor_type)
+        if extractor_type not in VALID_EXTRACTORS:
+            raise ValueError("service.extractor_type must be a valid extractor")
+        object.__setattr__(self, "extractor_type", extractor_type)
 
 
 @dataclass(frozen=True)
@@ -266,6 +282,7 @@ def load_config(path: Path) -> QueueWavesConfig:
             promql=s["promql"],
             layer=s.get("layer", "micro"),
             channel=s.get("channel", "P"),
+            extractor_type=s.get("extractor_type"),
         )
         for s in raw.get("services", [])
     ]
@@ -338,7 +355,9 @@ class ConfigCompiler:
             )
 
             for svc in svcs:
-                ext = "hilbert" if svc.channel == "P" else "event"
+                ext = svc.extractor_type
+                if ext is None:
+                    raise ValueError("service.extractor_type was not resolved")
                 osc_families[svc.name] = OscillatorFamily(
                     channel=svc.channel, extractor_type=ext, config={}
                 )

--- a/tests/apps/queuewaves/test_config.py
+++ b/tests/apps/queuewaves/test_config.py
@@ -123,6 +123,37 @@ def test_config_compiler_oscillator_families(minimal_config: QueueWavesConfig) -
     assert spec.oscillator_families["svc-a"].extractor_type == "hilbert"
 
 
+def test_config_compiler_accepts_standard_and_named_channels(tmp_path: Path) -> None:
+    yaml_text = textwrap.dedent("""\
+        prometheus_url: "http://prom:9090"
+        services:
+          - name: latency
+            promql: histogram_quantile(0.99, rate(http_duration_bucket[5m]))
+            layer: micro
+            channel: P
+          - name: release-state
+            promql: deployment_state
+            layer: meso
+            channel: S
+          - name: retry-budget
+            promql: retry_budget_remaining
+            layer: macro
+            channel: RetryBudget
+            extractor_type: event
+    """)
+    path = tmp_path / "qw-nchannel.yaml"
+    path.write_text(yaml_text, encoding="utf-8")
+
+    spec = ConfigCompiler().compile(load_config(path))
+
+    assert spec.oscillator_families["latency"].channel == "P"
+    assert spec.oscillator_families["latency"].extractor_type == "hilbert"
+    assert spec.oscillator_families["release-state"].channel == "S"
+    assert spec.oscillator_families["release-state"].extractor_type == "ring"
+    assert spec.oscillator_families["retry-budget"].channel == "RetryBudget"
+    assert spec.oscillator_families["retry-budget"].extractor_type == "event"
+
+
 def test_load_config_defaults(tmp_path: Path) -> None:
     yaml_text = textwrap.dedent("""\
         prometheus_url: "http://prom:9090"
@@ -217,9 +248,19 @@ def test_load_config_normalises_numeric_scalars(tmp_path: Path) -> None:
             services:
               - name: s1
                 promql: up
-                channel: X
+                channel: 1bad
             """,
             "service.channel",
+        ),
+        (
+            """\
+            prometheus_url: "http://prom:9090"
+            services:
+              - name: s1
+                promql: up
+                channel: ExtraChannel
+            """,
+            "service.extractor_type",
         ),
         (
             """\
@@ -267,7 +308,15 @@ def test_load_config_rejects_invalid_values(
 @pytest.mark.parametrize(
     "factory",
     [
-        lambda: ServiceDef(name="svc", promql="up", layer="micro", channel="S"),
+        lambda: ServiceDef(name="svc", promql="up", layer="micro", channel="1bad"),
+        lambda: ServiceDef(name="svc", promql="up", layer="micro", channel="Extra"),
+        lambda: ServiceDef(
+            name="svc",
+            promql="up",
+            layer="micro",
+            channel="Extra",
+            extractor_type="unknown",
+        ),
         lambda: ThresholdConfig(r_bad_warn=2.0, r_bad_critical=1.0),
         lambda: CouplingConfig(strength=-0.1),
         lambda: AlertSink(url="ftp://example.com/hook"),

--- a/tests/test_queuewaves_pipeline.py
+++ b/tests/test_queuewaves_pipeline.py
@@ -41,6 +41,37 @@ def test_compiler_produces_valid_spec():
     assert 1 in spec.objectives.good_layers
 
 
+def test_compiler_preserves_named_extension_channels():
+    cfg = QueueWavesConfig(
+        prometheus_url="http://localhost:9090",
+        services=[
+            ServiceDef(name="cpu", promql="cpu", layer="micro", channel="P"),
+            ServiceDef(name="events", promql="events", layer="meso", channel="I"),
+            ServiceDef(name="state", promql="state", layer="macro", channel="S"),
+            ServiceDef(
+                name="quantum",
+                promql="quantum",
+                layer="macro",
+                channel="Q_control",
+                extractor_type="event",
+            ),
+        ],
+        scrape_interval_s=1.0,
+        buffer_length=16,
+    )
+
+    spec = ConfigCompiler().compile(cfg)
+
+    assert spec.oscillator_families["cpu"].channel == "P"
+    assert spec.oscillator_families["cpu"].extractor_type == "hilbert"
+    assert spec.oscillator_families["events"].channel == "I"
+    assert spec.oscillator_families["events"].extractor_type == "event"
+    assert spec.oscillator_families["state"].channel == "S"
+    assert spec.oscillator_families["state"].extractor_type == "ring"
+    assert spec.oscillator_families["quantum"].channel == "Q_control"
+    assert spec.oscillator_families["quantum"].extractor_type == "event"
+
+
 def test_pipeline_tick():
     cfg = _make_config()
     pipeline = PhaseComputePipeline(cfg)


### PR DESCRIPTION
Summary: extends QueueWaves service configs from fixed P/I channels to the binding contract's channel IDs. Standard P, I, and S channels keep default extractor semantics; named channels are accepted only with explicit extractor_type. The guide documents the N-channel config path. Local validation: ruff check on changed Python, pytest tests/apps/queuewaves/test_config.py, mypy on QueueWaves config, pytest tests/apps/queuewaves, mkdocs build, staged diff check. Full pytest/coverage delegated to remote CI under the temporary hardware override rule.