### PR TITLE
Document core public API methods

### DIFF
--- a/spo-kernel/crates/spo-ffi/src/lib.rs
+++ b/spo-kernel/crates/spo-ffi/src/lib.rs
@@ -243,6 +243,29 @@ struct PyUPDEStepper {
 
 #[pymethods]
 impl PyUPDEStepper {
+    /// Create a Rust-backed UPDE stepper.
+    ///
+    /// Parameters
+    /// ----------
+    /// n
+    ///     Number of oscillators in every phase, frequency, and coupling
+    ///     input passed to `step` or `run`.
+    /// dt
+    ///     Base integration timestep in seconds.
+    /// method
+    ///     Integration method: `"euler"`, `"rk4"`, or `"rk45"`.
+    /// n_substeps
+    ///     Number of substeps retained in the integration configuration.
+    /// atol
+    ///     Absolute tolerance used by adaptive RK45.
+    /// rtol
+    ///     Relative tolerance used by adaptive RK45.
+    ///
+    /// Raises
+    /// ------
+    /// ValueError
+    ///     If `method` is unknown or the integration configuration is
+    ///     rejected by the Rust kernel.
     #[new]
     #[pyo3(signature = (n, dt = 0.01, method = "euler", n_substeps = 1, atol = 1e-6, rtol = 1e-3))]
     fn new(

--- a/src/scpn_phase_orchestrator/coupling/knm.py
+++ b/src/scpn_phase_orchestrator/coupling/knm.py
@@ -92,7 +92,32 @@ class CouplingBuilder:
     def build(
         self, n_layers: int, base_strength: float, decay_alpha: float
     ) -> CouplingState:
-        """K_ij = base_strength * exp(-decay_alpha * |i - j|), zero diagonal."""
+        """Build an exponentially decayed phase-coupling matrix.
+
+        Parameters
+        ----------
+        n_layers
+            Number of hierarchy layers or oscillators represented in the
+            square coupling matrix.
+        base_strength
+            Coupling strength before distance decay is applied.
+        decay_alpha
+            Non-negative exponential decay coefficient in
+            ``exp(-decay_alpha * |i - j|)``.
+
+        Returns
+        -------
+        CouplingState
+            Coupling snapshot with ``knm`` and ``alpha`` matrices of shape
+            ``(n_layers, n_layers)``. The diagonal of ``knm`` is zero and
+            ``alpha`` is initialised to zeros.
+
+        Notes
+        -----
+        When the Rust extension is available, construction dispatches to
+        ``spo_kernel.PyCouplingBuilder`` and preserves the same output
+        contract as the NumPy fallback.
+        """
         if _HAS_RUST:  # pragma: no cover
             from spo_kernel import PyCouplingBuilder
 

--- a/src/scpn_phase_orchestrator/monitor/boundaries.py
+++ b/src/scpn_phase_orchestrator/monitor/boundaries.py
@@ -46,7 +46,29 @@ class BoundaryObserver:
     def observe(
         self, values: dict[str, float], *, step: int | None = None
     ) -> BoundaryState:
-        """Check *values* against all boundary definitions, return violations."""
+        """Evaluate scalar measurements against configured boundaries.
+
+        Parameters
+        ----------
+        values
+            Mapping from monitored variable name to the current scalar
+            measurement.
+        step
+            Optional supervisor step attached to any posted
+            ``boundary_breach`` event. When omitted, the observer reuses
+            its previous step counter.
+
+        Returns
+        -------
+        BoundaryState
+            Partitioned violation snapshot containing all violations plus
+            soft and hard subsets.
+
+        Notes
+        -----
+        Missing variables are ignored. Unknown severities are logged and
+        treated as hard violations so safety-critical callers fail closed.
+        """
         if step is not None:
             self._step = step
         state = BoundaryState()

--- a/src/scpn_phase_orchestrator/upde/engine.py
+++ b/src/scpn_phase_orchestrator/upde/engine.py
@@ -120,7 +120,36 @@ class UPDEEngine:
         psi: float,
         alpha: NDArray,
     ) -> NDArray:
-        """Advance phases by one timestep, return new phases in [0, 2*pi)."""
+        """Advance one UPDE integration step.
+
+        Parameters
+        ----------
+        phases
+            Current oscillator phases, shape ``(n_oscillators,)``.
+        omegas
+            Natural angular frequencies in radians per second, shape
+            ``(n_oscillators,)``.
+        knm
+            Coupling matrix ``K_nm`` with shape
+            ``(n_oscillators, n_oscillators)``.
+        zeta
+            External drive strength.
+        psi
+            External drive phase target in radians.
+        alpha
+            Sakaguchi phase-lag matrix with the same shape as ``knm``.
+
+        Returns
+        -------
+        numpy.ndarray
+            New phases wrapped into ``[0, 2*pi)``.
+
+        Raises
+        ------
+        ValueError
+            If input shapes do not match the configured oscillator count
+            or any scalar/array input is non-finite.
+        """
         self._validate_inputs(phases, omegas, knm, alpha, zeta, psi)
         with self._lock:
             if self._rust is not None:  # pragma: no cover

--- a/src/scpn_phase_orchestrator/upde/swarmalator.py
+++ b/src/scpn_phase_orchestrator/upde/swarmalator.py
@@ -209,6 +209,36 @@ class SwarmalatorEngine:
         j: float = 1.0,
         k: float = 1.0,
     ) -> tuple[NDArray, NDArray]:
+        """Advance coupled swarmalator positions and phases by one step.
+
+        Parameters
+        ----------
+        pos
+            Agent positions with shape ``(n_agents, dim)``.
+        phases
+            Agent phases in radians, shape ``(n_agents,)``.
+        omegas
+            Natural angular frequencies, shape ``(n_agents,)``.
+        a
+            Baseline spatial attraction coefficient.
+        b
+            Spatial repulsion coefficient.
+        j
+            Phase-dependent attraction modulation.
+        k
+            Phase-coupling coefficient.
+
+        Returns
+        -------
+        tuple[numpy.ndarray, numpy.ndarray]
+            Updated positions with shape ``(n_agents, dim)`` and updated
+            phases wrapped into ``[0, 2*pi)``.
+
+        Notes
+        -----
+        The dispatcher selects the first available accelerated backend and
+        falls back to the NumPy reference path with the same state contract.
+        """
         backend_fn = _dispatch()
         if backend_fn is not None:
             return backend_fn(

--- a/tests/test_public_api_docstrings.py
+++ b/tests/test_public_api_docstrings.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Commercial license available
+# © Concepts 1996–2026 Miroslav Šotek. All rights reserved.
+# © Code 2020–2026 Miroslav Šotek. All rights reserved.
+# ORCID: 0009-0009-3560-0851
+# Contact: www.anulum.li | protoscience@anulum.li
+# SCPN Phase Orchestrator — Public API docstring regressions
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from scpn_phase_orchestrator.coupling.knm import CouplingBuilder
+from scpn_phase_orchestrator.monitor.boundaries import BoundaryObserver
+from scpn_phase_orchestrator.upde.engine import UPDEEngine
+from scpn_phase_orchestrator.upde.swarmalator import SwarmalatorEngine
+
+
+@pytest.mark.parametrize(
+    ("target", "sections"),
+    [
+        (UPDEEngine.step, ("Parameters", "Returns", "Raises")),
+        (CouplingBuilder.build, ("Parameters", "Returns", "Notes")),
+        (SwarmalatorEngine.step, ("Parameters", "Returns", "Notes")),
+        (BoundaryObserver.observe, ("Parameters", "Returns", "Notes")),
+    ],
+)
+def test_core_public_methods_use_numpy_style_docstrings(
+    target: Callable[..., object], sections: tuple[str, ...]
+) -> None:
+    doc = inspect.getdoc(target)
+
+    assert doc is not None
+    for section in sections:
+        assert section in doc
+        assert f"{section}\n{'-' * len(section)}" in doc
+
+
+def test_rust_upde_stepper_constructor_documents_public_contract() -> None:
+    rust_source = Path("spo-kernel/crates/spo-ffi/src/lib.rs").read_text(
+        encoding="utf-8"
+    )
+    stepper_start = rust_source.index('pyclass(name = "PyUPDEStepper")')
+    constructor_start = rust_source.index("fn new(", stepper_start)
+    constructor_doc = rust_source[stepper_start:constructor_start]
+
+    assert "Create a Rust-backed UPDE stepper." in constructor_doc
+    assert "Parameters" in constructor_doc
+    assert "Raises" in constructor_doc
+    assert "method" in constructor_doc
+    assert "ValueError" in constructor_doc


### PR DESCRIPTION
Summary: addresses the U5 docstring backlog item by adding NumPy-style public API docstrings for UPDEEngine.step, CouplingBuilder.build, SwarmalatorEngine.step, BoundaryObserver.observe, and the Rust PyUPDEStepper constructor. Adds regression coverage for docstring sections. Local validation: ruff check, ruff format --check, pytest tests/test_public_api_docstrings.py, mypy on touched Python modules, cargo fmt --manifest-path spo-kernel/crates/spo-ffi/Cargo.toml --check, mkdocs build. Full pytest/coverage delegated to remote CI under the temporary hardware override rule.