### PR TITLE
Justify source type ignores

### DIFF
--- a/src/scpn_phase_orchestrator/adapters/hardware_io.py
+++ b/src/scpn_phase_orchestrator/adapters/hardware_io.py
@@ -30,6 +30,7 @@ __all__ = [
 ]
 
 try:
+    # type ignore: BrainFlow is optional and lacks complete typing metadata.
     from brainflow.board_shim import (  # type: ignore[import-not-found,import-untyped]  # pragma: no cover
         BoardShim,
         BrainFlowInputParams,
@@ -40,6 +41,7 @@ except ImportError:
     HAS_BRAINFLOW = False
 
 try:
+    # type ignore: pymodbus is optional for hardware adapter deployments.
     from pymodbus.client import (  # type: ignore[import-not-found]
         ModbusTcpClient,  # pragma: no cover
     )

--- a/src/scpn_phase_orchestrator/adapters/modbus_tls.py
+++ b/src/scpn_phase_orchestrator/adapters/modbus_tls.py
@@ -20,10 +20,12 @@ from pathlib import Path
 __all__ = ["SecureModbusAdapter", "HAS_PYMODBUS"]
 
 try:
+    # type ignore: pymodbus is optional and has incomplete typing on supported releases.
     from pymodbus.client import ModbusTlsClient  # type: ignore[import-not-found]
 
     HAS_PYMODBUS = True
 except ImportError:
+    # type ignore: None sentinel mirrors the optional pymodbus import boundary.
     ModbusTlsClient = None  # type: ignore[assignment,misc]
     HAS_PYMODBUS = False
 
@@ -103,6 +105,7 @@ class SecureModbusAdapter:
 
         Raises ConnectionError if the read fails or returns an error frame.
         """
+        # type ignore: optional pymodbus client is stored as object after runtime guard.
         result = self._client.read_holding_registers(  # type: ignore[attr-defined]
             address, count=1
         )
@@ -115,6 +118,7 @@ class SecureModbusAdapter:
 
         Raises ConnectionError if the write fails.
         """
+        # type ignore: optional pymodbus client is stored as object after runtime guard.
         result = self._client.write_register(address, value)  # type: ignore[attr-defined]
         if result.isError():
             raise ConnectionError(f"Modbus write error at address {address}: {result}")
@@ -122,6 +126,7 @@ class SecureModbusAdapter:
     def validate_connection(self) -> bool:
         """Return True if the TLS-wrapped Modbus connection is active."""
         try:
+            # type ignore: optional pymodbus client is stored as object.
             return bool(self._client.connected)  # type: ignore[attr-defined]
         except Exception:
             return False

--- a/src/scpn_phase_orchestrator/adapters/redis_store.py
+++ b/src/scpn_phase_orchestrator/adapters/redis_store.py
@@ -18,6 +18,7 @@ try:
 
     _HAS_REDIS = True
 except ModuleNotFoundError:  # pragma: no cover
+    # type ignore: optional redis dependency uses a None module sentinel.
     _redis_mod = None  # type: ignore[assignment]
     _HAS_REDIS = False
 

--- a/src/scpn_phase_orchestrator/adapters/snn_bridge.py
+++ b/src/scpn_phase_orchestrator/adapters/snn_bridge.py
@@ -126,6 +126,7 @@ class SNNControllerBridge:
 
         Raises ImportError if lava-nc is not installed.
         """
+        # type ignore: lava-nc is an optional dependency without bundled stubs.
         from lava.proc.lif.process import LIF  # type: ignore[import-not-found]
 
         return LIF(

--- a/src/scpn_phase_orchestrator/apps/queuewaves/alerter.py
+++ b/src/scpn_phase_orchestrator/apps/queuewaves/alerter.py
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 try:
     from httpx import HTTPError as _HTTPError
 except ImportError:  # pragma: no cover
+    # type ignore: optional httpx dependency falls back to a base I/O error.
     _HTTPError = OSError  # type: ignore[assignment,misc]
 
 _SEND_ERRORS: tuple[type[BaseException], ...] = (OSError, RuntimeError, _HTTPError)

--- a/src/scpn_phase_orchestrator/apps/queuewaves/collector.py
+++ b/src/scpn_phase_orchestrator/apps/queuewaves/collector.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 try:
     from httpx import HTTPError as _HTTPError
 except ImportError:  # pragma: no cover
+    # type ignore: optional httpx dependency falls back to a base I/O error.
     _HTTPError = OSError  # type: ignore[assignment,misc]
 
 _SCRAPE_ERRORS: tuple[type[BaseException], ...] = (OSError, RuntimeError, _HTTPError)

--- a/src/scpn_phase_orchestrator/apps/queuewaves/server.py
+++ b/src/scpn_phase_orchestrator/apps/queuewaves/server.py
@@ -20,6 +20,7 @@ from typing import Any
 try:
     from httpx import HTTPError as _HTTPError
 except ImportError:  # pragma: no cover
+    # type ignore: optional httpx dependency falls back to a base I/O error.
     _HTTPError = OSError  # type: ignore[assignment,misc]
 
 from scpn_phase_orchestrator.apps.queuewaves.alerter import WebhookAlerter
@@ -315,4 +316,5 @@ def run_server(config_path: str, host: str = "127.0.0.1", port: int = 8080) -> N
 
     cfg = load_config(Path(config_path))
     app = create_app(cfg)
+    # type ignore: uvicorn's app parameter typing is narrower than FastAPI instances.
     uvicorn.run(app, host=host, port=port, log_level="info")  # type: ignore[arg-type]

--- a/src/scpn_phase_orchestrator/cli.py
+++ b/src/scpn_phase_orchestrator/cli.py
@@ -285,6 +285,7 @@ def run(binding_spec: str, steps: int, audit: str | None, seed: int) -> None:
                     zeta,
                     psi_target,
                     eff_alpha,
+                    # type ignore: amplitude_mode proves spec.amplitude is set here.
                     epsilon=spec.amplitude.epsilon,  # type: ignore[union-attr]
                 )
                 phases = sl_state[:n_osc]
@@ -441,6 +442,7 @@ def run(binding_spec: str, steps: int, audit: str | None, seed: int) -> None:
                     log_kwargs["amplitudes"] = amplitudes
                     log_kwargs["mu"] = eff_mu
                     log_kwargs["knm_r"] = coupling.knm_r
+                    # type ignore: amplitude_mode proves spec.amplitude is set here.
                     log_kwargs["epsilon"] = spec.amplitude.epsilon  # type: ignore[union-attr]
                 audit_logger.log_step(
                     step_idx,

--- a/src/scpn_phase_orchestrator/coupling/connectome.py
+++ b/src/scpn_phase_orchestrator/coupling/connectome.py
@@ -49,7 +49,7 @@ def load_neurolib_hcp(n_regions: int = 80) -> NDArray:
         ValueError: If n_regions < 2 or > 80.
     """
     try:
-        # neurolib is optional and currently lacks complete type metadata;
+        # type ignore: neurolib is optional and currently lacks complete type metadata;
         # runtime availability is handled by the ModuleNotFoundError branch.
         from neurolib.utils.loadData import (  # type: ignore[import-untyped,import-not-found]
             Dataset,

--- a/src/scpn_phase_orchestrator/grpc_gen/__init__.py
+++ b/src/scpn_phase_orchestrator/grpc_gen/__init__.py
@@ -21,6 +21,7 @@ USING_GENERATED_PB2: bool
 USING_GENERATED_GRPC: bool
 
 try:
+    # type ignore: generated protobuf modules expose runtime attributes mypy cannot see.
     from scpn_phase_orchestrator.grpc_gen.spo_pb2 import (  # type: ignore[attr-defined]
         ConfigRequest,
         ConfigResponse,
@@ -55,6 +56,7 @@ try:
 
     USING_GENERATED_GRPC = True
 except Exception:  # pragma: no cover
+    # type ignore: fallback servicer intentionally substitutes generated grpc types.
     from scpn_phase_orchestrator.grpc_gen._spo_pb2_grpc_fallback import (  # type: ignore[assignment]
         PhaseOrchestratorServicer,
         add_PhaseOrchestratorServicer_to_server,

--- a/src/scpn_phase_orchestrator/grpc_gen/_spo_pb2_grpc_fallback.py
+++ b/src/scpn_phase_orchestrator/grpc_gen/_spo_pb2_grpc_fallback.py
@@ -65,6 +65,7 @@ def add_PhaseOrchestratorServicer_to_server(
     This fallback version requires grpcio at runtime.
     """
     try:
+        # type ignore: grpcio is optional and untyped in this fallback path.
         import grpc  # type: ignore[import-untyped]
     except ImportError as exc:
         msg = "grpcio required to register servicer on a live server"

--- a/src/scpn_phase_orchestrator/nn/training.py
+++ b/src/scpn_phase_orchestrator/nn/training.py
@@ -46,6 +46,7 @@ def sync_loss(
     Returns:
         Scalar loss (R - target_R)^2
     """
+    # type ignore: Equinox modules expose __call__ dynamically by subclass.
     final = model(phases)  # type: ignore[operator]
     R = order_parameter(final)
     return (R - target_R) ** 2
@@ -68,6 +69,7 @@ def trajectory_loss(
     Returns:
         Scalar mean circular distance
     """
+    # type ignore: training accepts the trajectory-capable Equinox protocol.
     _, predicted = model.forward_with_trajectory(phases)  # type: ignore[attr-defined]
     T = min(predicted.shape[0], observed.shape[0])
     pred = predicted[:T]

--- a/src/scpn_phase_orchestrator/server.py
+++ b/src/scpn_phase_orchestrator/server.py
@@ -65,8 +65,11 @@ try:
         WebSocketDisconnect,  # pragma: no cover
     )
 except ImportError:  # pragma: no cover
+    # type ignore: FastAPI is optional; sentinels keep module importable without it.
     Response = None  # type: ignore[assignment,misc]  # pragma: no cover
+    # type ignore: FastAPI is optional; sentinels keep module importable without it.
     WebSocket = None  # type: ignore[assignment,misc]  # pragma: no cover
+    # type ignore: FastAPI is optional; sentinels keep module importable without it.
     WebSocketDisconnect = None  # type: ignore[assignment,misc]  # pragma: no cover
 
 __all__ = ["create_app", "SimulationState"]

--- a/src/scpn_phase_orchestrator/server_grpc.py
+++ b/src/scpn_phase_orchestrator/server_grpc.py
@@ -42,6 +42,7 @@ logger = logging.getLogger(__name__)
 __all__ = ["PhaseStreamServicer", "HAS_GRPC"]
 
 try:
+    # type ignore: grpcio ships without complete typing in the supported range.
     import grpc  # type: ignore[import-untyped]  # pragma: no cover
 
     HAS_GRPC = True  # pragma: no cover

--- a/src/scpn_phase_orchestrator/upde/jax_engine.py
+++ b/src/scpn_phase_orchestrator/upde/jax_engine.py
@@ -39,10 +39,12 @@ if TYPE_CHECKING:
     import jax.numpy as jnp
 
 
+# type ignore: JAX tracer callables need dynamic signatures for jit wrapping.
 def _build_jax_step():  # type: ignore[no-untyped-def]  # pragma: no cover
     """Build JIT-compiled Kuramoto step function."""
 
     @jit
+    # type ignore: JAX tracer callable signatures are intentionally dynamic.
     def _kuramoto_step(phases, omegas, knm, zeta, psi, alpha, dt):  # type: ignore[no-untyped-def]
         diff = phases[jnp.newaxis, :] - phases[:, jnp.newaxis]
         coupling = jnp.sum(knm * jnp.sin(diff - alpha), axis=1)
@@ -52,7 +54,9 @@ def _build_jax_step():  # type: ignore[no-untyped-def]  # pragma: no cover
         return new_phases % (2.0 * jnp.pi)
 
     @jit
+    # type ignore: JAX tracer callable signatures are intentionally dynamic.
     def _kuramoto_rk4(phases, omegas, knm, zeta, psi, alpha, dt):  # type: ignore[no-untyped-def]
+        # type ignore: nested derivative keeps JAX tracer polymorphism.
         def deriv(p):  # type: ignore[no-untyped-def]
             """Kuramoto coupling derivative at given phases."""
             diff = p[jnp.newaxis, :] - p[:, jnp.newaxis]
@@ -69,13 +73,16 @@ def _build_jax_step():  # type: ignore[no-untyped-def]  # pragma: no cover
     return _kuramoto_step, _kuramoto_rk4
 
 
+# type ignore: JAX tracer callables need dynamic signatures for jit wrapping.
 def _build_jax_sl_step():  # type: ignore[no-untyped-def]  # pragma: no cover
     """Build JIT-compiled Stuart-Landau step function."""
 
     @jit
+    # type ignore: JAX tracer callable signatures are intentionally dynamic.
     def _sl_rk4(state, omegas, mu, knm, knm_r, zeta, psi, alpha, epsilon, dt):  # type: ignore[no-untyped-def]
         n = omegas.shape[0]
 
+        # type ignore: nested derivative keeps JAX tracer polymorphism.
         def deriv(s):  # type: ignore[no-untyped-def]
             """Stuart-Landau coupled (phase, amplitude) derivative."""
             th, am = s[:n], s[n:]

--- a/src/scpn_phase_orchestrator/upde/prediction.py
+++ b/src/scpn_phase_orchestrator/upde/prediction.py
@@ -254,6 +254,7 @@ class VariationalPredictor:
         # Gradient descent on F w.r.t. mu:
         # dF/dmu = -precision * error  (since F ~ precision * error^2 / 2)
         # mu_new = mu - lr * dF/dmu = mu + lr * precision * error
+        # type ignore: modulo preserves ndarray shape, but mypy narrows to scalar.
         self._mu = (self._mu + self._lr * self._precision * error) % TWO_PI  # type: ignore[assignment]
 
         # Update precision from error variance (online).

--- a/src/scpn_phase_orchestrator/visualization/streamer.py
+++ b/src/scpn_phase_orchestrator/visualization/streamer.py
@@ -20,6 +20,7 @@ try:
 
     HAS_WEBSOCKETS = True
 except ImportError:
+    # type ignore: optional websockets dependency uses a None sentinel fallback.
     websockets = None  # type: ignore[assignment]
     HAS_WEBSOCKETS = False
 

--- a/tests/test_type_ignore_justifications.py
+++ b/tests/test_type_ignore_justifications.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Commercial license available
+# © Concepts 1996–2026 Miroslav Šotek. All rights reserved.
+# © Code 2020–2026 Miroslav Šotek. All rights reserved.
+# ORCID: 0009-0009-3560-0851
+# Contact: www.anulum.li | protoscience@anulum.li
+# SCPN Phase Orchestrator — type ignore justification regression
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _has_type_ignore_reason(lines: list[str], index: int) -> bool:
+    line = lines[index]
+    directive = "# type: ignore"
+    suffix = line.split(directive, 1)[1]
+    if "type ignore:" in line:
+        return True
+    if "#" in suffix and "pragma:" not in suffix:
+        return True
+    previous = lines[max(0, index - 2) : index]
+    return any("type ignore:" in item for item in previous)
+
+
+def test_source_type_ignores_have_local_justification() -> None:
+    missing: list[str] = []
+    for path in sorted(Path("src/scpn_phase_orchestrator").rglob("*.py")):
+        lines = path.read_text(encoding="utf-8").splitlines()
+        for index, line in enumerate(lines):
+            if "# type: ignore" not in line:
+                continue
+            if not _has_type_ignore_reason(lines, index):
+                missing.append(f"{path}:{index + 1}")
+
+    assert missing == []


### PR DESCRIPTION
Summary: adds local rationale comments for every source-tree type-ignore directive and adds a regression test that fails if source ignores lack a nearby reason. This closes the V2 unjustified type-ignore audit debt without changing runtime behaviour. Local validation: pytest tests/test_type_ignore_justifications.py, ruff check src/scpn_phase_orchestrator tests/test_type_ignore_justifications.py, ruff format --check src/scpn_phase_orchestrator tests/test_type_ignore_justifications.py, targeted mypy over touched source files and the regression test. Full pytest/coverage delegated to remote CI under the temporary hardware override rule.