### PR TITLE
Add structured server request logging

### DIFF
--- a/src/scpn_phase_orchestrator/server.py
+++ b/src/scpn_phase_orchestrator/server.py
@@ -33,6 +33,8 @@ import json
 import logging
 import os
 import threading
+import time
+from collections.abc import Awaitable, Callable
 from pathlib import Path
 
 import numpy as np
@@ -407,6 +409,34 @@ def create_app(spec_path: str | Path) -> object:  # pragma: no cover
                 sim.event_bus.clear()
 
     app = FastAPI(title="SPO Dashboard", version="0.5.0", lifespan=_lifespan)
+
+    @app.middleware("http")
+    async def _log_http_request(
+        request: FastAPIRequest,
+        call_next: Callable[[FastAPIRequest], Awaitable[Response]],
+    ) -> Response:
+        start = time.perf_counter()
+        status_code = 500
+        try:
+            response = await call_next(request)
+            status_code = response.status_code
+            return response
+        finally:
+            duration_ms = (time.perf_counter() - start) * 1000.0
+            path = request.url.path
+            logger.info(
+                "http.request: method=%s path=%s status_code=%d duration_ms=%.3f",
+                request.method,
+                path,
+                status_code,
+                duration_ms,
+                extra={
+                    "http_method": request.method,
+                    "http_path": path,
+                    "status_code": status_code,
+                    "duration_ms": duration_ms,
+                },
+            )
 
     _api_key = os.environ.get("SPO_API_KEY")
     _production = is_production_mode("SPO")

--- a/src/scpn_phase_orchestrator/server_grpc.py
+++ b/src/scpn_phase_orchestrator/server_grpc.py
@@ -70,6 +70,33 @@ def _snap_to_response(snap: dict) -> StateResponse:
     )
 
 
+def _log_state_rpc(
+    rpc: str,
+    response: StateResponse,
+    *,
+    level: int = logging.INFO,
+    n_steps: int | None = None,
+) -> None:
+    extra = {
+        "rpc": rpc,
+        "step": response.step,
+        "R_global": response.R_global,
+        "regime": response.regime,
+        "status": "ok",
+    }
+    if n_steps is not None:
+        extra["n_steps"] = n_steps
+    logger.log(
+        level,
+        "grpc.%s: step=%d R_global=%.4f regime=%s",
+        rpc,
+        response.step,
+        response.R_global,
+        response.regime,
+        extra=extra,
+    )
+
+
 class PhaseStreamServicer(PhaseOrchestratorServicer):
     """gRPC servicer that exposes state, step, reset, streaming, and config.
 
@@ -120,7 +147,9 @@ class PhaseStreamServicer(PhaseOrchestratorServicer):
         """gRPC unary RPC: return current simulation state."""
         self._authorise(context)
         with self._lock:
-            return _snap_to_response(self._sim.snapshot())
+            response = _snap_to_response(self._sim.snapshot())
+        _log_state_rpc("GetState", response)
+        return response
 
     def Step(self, request: Any, context: Any) -> StateResponse:
         """gRPC unary RPC: advance simulation by n_steps and return state."""
@@ -130,13 +159,7 @@ class PhaseStreamServicer(PhaseOrchestratorServicer):
             for _ in range(n):
                 self._sim.step()
             response = _snap_to_response(self._sim.snapshot())
-        logger.debug(
-            "grpc.Step: n_steps=%d step=%d R_global=%.4f regime=%s",
-            n,
-            response.step,
-            response.R_global,
-            response.regime,
-        )
+        _log_state_rpc("Step", response, n_steps=n)
         return response
 
     def Reset(self, request: Any, context: Any) -> StateResponse:
@@ -145,14 +168,14 @@ class PhaseStreamServicer(PhaseOrchestratorServicer):
         with self._lock:
             self._sim.reset()
             response = _snap_to_response(self._sim.snapshot())
-        logger.info("grpc.Reset: step=%d regime=%s", response.step, response.regime)
+        _log_state_rpc("Reset", response)
         return response
 
     def GetConfig(self, request: Any, context: Any) -> ConfigResponse:
         """gRPC unary RPC: return engine configuration."""
         self._authorise(context)
         spec = self._sim.spec
-        return ConfigResponse(
+        response = ConfigResponse(
             name=spec.name,
             n_oscillators=self._sim.n_osc,
             n_layers=len(spec.layers),
@@ -160,6 +183,20 @@ class PhaseStreamServicer(PhaseOrchestratorServicer):
             sample_period_s=spec.sample_period_s,
             control_period_s=spec.control_period_s,
         )
+        logger.info(
+            "grpc.GetConfig: name=%s n_oscillators=%d n_layers=%d",
+            response.name,
+            response.n_oscillators,
+            response.n_layers,
+            extra={
+                "rpc": "GetConfig",
+                "config_name": response.name,
+                "n_oscillators": response.n_oscillators,
+                "n_layers": response.n_layers,
+                "status": "ok",
+            },
+        )
+        return response
 
     # -- server-streaming RPC -------------------------------------------------
 
@@ -168,14 +205,50 @@ class PhaseStreamServicer(PhaseOrchestratorServicer):
         self._authorise(context)
         max_steps = getattr(request, "max_steps", 100) or 100
         interval = getattr(request, "interval_s", 0.05) or 0.05
+        emitted = 0
+        logger.info(
+            "grpc.StreamPhases.start: max_steps=%d interval_s=%.4f",
+            max_steps,
+            interval,
+            extra={
+                "rpc": "StreamPhases",
+                "stream_event": "start",
+                "max_steps": max_steps,
+                "interval_s": interval,
+                "status": "ok",
+            },
+        )
         for _ in range(max_steps):
             if (
                 context is not None
                 and hasattr(context, "is_active")
                 and not context.is_active()
             ):
+                logger.info(
+                    "grpc.StreamPhases.stop: emitted=%d reason=inactive_context",
+                    emitted,
+                    extra={
+                        "rpc": "StreamPhases",
+                        "stream_event": "stop",
+                        "emitted": emitted,
+                        "reason": "inactive_context",
+                        "status": "ok",
+                    },
+                )
                 return
             with self._lock:
                 snap = self._sim.snapshot()
             yield _snap_to_response(snap)
+            emitted += 1
             time.sleep(interval)
+        logger.info(
+            "grpc.StreamPhases.stop: emitted=%d reason=max_steps",
+            emitted,
+            extra={
+                "rpc": "StreamPhases",
+                "stream_event": "stop",
+                "emitted": emitted,
+                "reason": "max_steps",
+                "status": "ok",
+            },
+        )

--- a/tests/test_server_logging.py
+++ b/tests/test_server_logging.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import pytest
@@ -26,6 +27,10 @@ from scpn_phase_orchestrator.upde.metrics import LayerState, UPDEState
 DOMAINPACK_DIR = Path(__file__).parent.parent / "domainpacks"
 
 
+def _extra(record: logging.LogRecord, key: str) -> Any:
+    return record.__dict__[key]
+
+
 def _make_state(regime_id: str, stability: float = 0.5) -> UPDEState:
     return UPDEState(
         layers=[LayerState(R=stability, psi=0.0) for _ in range(3)],
@@ -33,6 +38,14 @@ def _make_state(regime_id: str, stability: float = 0.5) -> UPDEState:
         stability_proxy=stability,
         regime_id=regime_id,
     )
+
+
+class _DegradedRegimeManager(RegimeManager):
+    def evaluate(self, *_args: Any, **_kwargs: Any) -> Regime:
+        return Regime.DEGRADED
+
+    def transition(self, proposed: Regime) -> Regime:
+        return proposed
 
 
 class TestSupervisorPolicyLogging:
@@ -53,8 +66,8 @@ class TestSupervisorPolicyLogging:
         assert records, "supervisor.decide did not emit a log record"
         rec = records[-1]
         assert "regime=" in rec.getMessage()
-        assert rec.n_actions == len(actions)
-        assert rec.regime in {r.value for r in Regime}
+        assert _extra(rec, "n_actions") == len(actions)
+        assert _extra(rec, "regime") in {r.value for r in Regime}
         assert "n_violations" in rec.__dict__
 
     def test_decide_extra_includes_knob_list(
@@ -69,9 +82,7 @@ class TestSupervisorPolicyLogging:
             logger="scpn_phase_orchestrator.supervisor.policy",
         )
         state = _make_state("degraded", stability=0.2)
-        # Force DEGRADED: we stub the regime manager to emit degraded.
-        policy._regime_manager.evaluate = lambda *_a, **_k: Regime.DEGRADED  # type: ignore[assignment]
-        policy._regime_manager.transition = lambda r: r  # type: ignore[assignment]
+        policy._regime_manager = _DegradedRegimeManager()
 
         actions = policy.decide(state, BoundaryState(violations=[]))
         assert all(isinstance(a, ControlAction) for a in actions)
@@ -79,10 +90,33 @@ class TestSupervisorPolicyLogging:
         records = [r for r in caplog.records if r.name.endswith("supervisor.policy")]
         assert records
         rec = records[-1]
-        assert rec.knobs == [a.knob for a in actions]
+        assert _extra(rec, "knobs") == [a.knob for a in actions]
 
 
 class TestServerGrpcLogging:
+    def test_get_state_emits_structured_info_log(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        spec = load_binding_spec(
+            DOMAINPACK_DIR / "minimal_domain" / "binding_spec.yaml"
+        )
+        sim = SimulationState(spec)
+        servicer = PhaseStreamServicer(sim)
+        caplog.set_level(logging.INFO, logger="scpn_phase_orchestrator.server_grpc")
+
+        response = servicer.GetState(request=None, context=None)
+
+        records = [
+            r
+            for r in caplog.records
+            if r.name.endswith("server_grpc") and getattr(r, "rpc", "") == "GetState"
+        ]
+        assert records, "GetState RPC did not emit a structured INFO log"
+        rec = records[-1]
+        assert _extra(rec, "step") == response.step
+        assert _extra(rec, "regime") == response.regime
+        assert _extra(rec, "status") == "ok"
+
     def test_reset_emits_info_log(self, caplog: pytest.LogCaptureFixture) -> None:
         spec = load_binding_spec(
             DOMAINPACK_DIR / "minimal_domain" / "binding_spec.yaml"
@@ -94,9 +128,64 @@ class TestServerGrpcLogging:
         servicer.Reset(request=None, context=None)
 
         records = [r for r in caplog.records if r.name.endswith("server_grpc")]
-        assert any("grpc.Reset" in r.getMessage() for r in records), (
-            "Reset RPC did not emit an INFO-level structured log"
+        reset_records = [r for r in records if getattr(r, "rpc", "") == "Reset"]
+        assert reset_records, "Reset RPC did not emit an INFO-level structured log"
+        rec = reset_records[-1]
+        assert "grpc.Reset" in rec.getMessage()
+        assert _extra(rec, "status") == "ok"
+
+    def test_step_log_includes_request_count(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        spec = load_binding_spec(
+            DOMAINPACK_DIR / "minimal_domain" / "binding_spec.yaml"
         )
+        sim = SimulationState(spec)
+        servicer = PhaseStreamServicer(sim)
+        request = type("StepRequest", (), {"n_steps": 3})()
+        caplog.set_level(logging.INFO, logger="scpn_phase_orchestrator.server_grpc")
+
+        response = servicer.Step(request=request, context=None)
+
+        records = [
+            r
+            for r in caplog.records
+            if r.name.endswith("server_grpc") and getattr(r, "rpc", "") == "Step"
+        ]
+        assert records
+        rec = records[-1]
+        assert _extra(rec, "n_steps") == 3
+        assert _extra(rec, "step") == response.step
+        assert response.step == 3
+
+
+class TestServerHttpLogging:
+    def test_http_middleware_logs_path_without_query(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        testclient = pytest.importorskip("fastapi.testclient")
+        from scpn_phase_orchestrator.server import create_app
+
+        app = create_app(DOMAINPACK_DIR / "minimal_domain" / "binding_spec.yaml")
+        client = testclient.TestClient(app)
+        caplog.set_level(logging.INFO, logger="scpn_phase_orchestrator.server")
+
+        response = client.get("/api/config?token=sensitive-value")
+
+        assert response.status_code == 200
+        records = [
+            r
+            for r in caplog.records
+            if r.name.endswith("server")
+            and getattr(r, "http_path", "") == "/api/config"
+        ]
+        assert records, "HTTP request middleware did not emit a structured log"
+        rec = records[-1]
+        assert _extra(rec, "http_method") == "GET"
+        assert _extra(rec, "status_code") == 200
+        assert _extra(rec, "duration_ms") >= 0.0
+        assert "sensitive-value" not in rec.getMessage()
+        assert "token" not in rec.getMessage()
 
 
 # Pipeline wiring: observability is the only tool an operator has when a


### PR DESCRIPTION
## Summary
- add FastAPI HTTP completion logging with method/path/status/duration fields while omitting query strings
- add structured gRPC audit fields for unary RPCs and stream lifecycle events
- expand logging regression coverage for HTTP, gRPC, and supervisor policy decision logs

## Validation
- .venv-linux/bin/ruff check src/scpn_phase_orchestrator/server.py src/scpn_phase_orchestrator/server_grpc.py tests/test_server_logging.py
- .venv-linux/bin/ruff format --check src/scpn_phase_orchestrator/server.py src/scpn_phase_orchestrator/server_grpc.py tests/test_server_logging.py
- .venv-linux/bin/python -m mypy src/scpn_phase_orchestrator/server.py src/scpn_phase_orchestrator/server_grpc.py tests/test_server_logging.py
- .venv-linux/bin/python -m pytest tests/test_server.py tests/test_server_grpc.py tests/test_server_logging.py
- .venv-linux/bin/python -m bandit -q src/scpn_phase_orchestrator/server.py src/scpn_phase_orchestrator/server_grpc.py

Full pytest/coverage gate is delegated to remote CI because local hardware is unsuitable under the temporary project rule.