### PR TITLE
Narrow server exception handling

### DIFF
--- a/src/scpn_phase_orchestrator/adapters/modbus_tls.py
+++ b/src/scpn_phase_orchestrator/adapters/modbus_tls.py
@@ -123,5 +123,5 @@ class SecureModbusAdapter:
         """Return True if the TLS-wrapped Modbus connection is active."""
         try:
             return bool(self._client.connected)  # type: ignore[attr-defined]
-        except Exception:
+        except (AttributeError, OSError, RuntimeError):
             return False

--- a/src/scpn_phase_orchestrator/server.py
+++ b/src/scpn_phase_orchestrator/server.py
@@ -74,6 +74,14 @@ __all__ = ["create_app", "SimulationState"]
 logger = logging.getLogger(__name__)
 
 TWO_PI = 2.0 * np.pi
+HEALTH_CHECK_EXCEPTIONS = (
+    RuntimeError,
+    ValueError,
+    TypeError,
+    KeyError,
+    IndexError,
+    FloatingPointError,
+)
 
 
 class SimulationState:
@@ -510,7 +518,7 @@ def create_app(spec_path: str | Path) -> object:  # pragma: no cover
             r_val = snap.get("R_global", float("nan"))
             checks["R_finite"] = "ok" if np.isfinite(r_val) else "error"
             checks["regime"] = "ok" if snap.get("regime") else "unknown"
-        except Exception as exc:
+        except HEALTH_CHECK_EXCEPTIONS as exc:
             checks["engine"] = f"error: {exc}"
 
         healthy = all(v == "ok" for v in checks.values())

--- a/tests/test_modbus_tls.py
+++ b/tests/test_modbus_tls.py
@@ -166,6 +166,36 @@ class TestSecureModbusAdapterTLS:
             adapter = SecureModbusAdapter("localhost", 802, cert, key)
             assert adapter.validate_connection() is False
 
+    def test_validate_connection_unexpected_exception_propagates(self, tmp_path):
+        cert = tmp_path / "client.pem"
+        key = tmp_path / "client.key"
+        cert.write_text("dummy-cert")
+        key.write_text("dummy-key")
+
+        mock_client = MagicMock()
+        mock_client.connect.return_value = True
+        type(mock_client).connected = property(
+            lambda self: (_ for _ in ()).throw(ValueError("bad state"))
+        )
+
+        with (
+            patch(
+                "scpn_phase_orchestrator.adapters.modbus_tls.ModbusTlsClient",
+                return_value=mock_client,
+            ),
+            patch("scpn_phase_orchestrator.adapters.modbus_tls.ssl") as mock_ssl,
+        ):
+            mock_ctx = MagicMock()
+            mock_ssl.SSLContext.return_value = mock_ctx
+            mock_ssl.PROTOCOL_TLS_CLIENT = 2
+            mock_ssl.SSLError = Exception
+
+            from scpn_phase_orchestrator.adapters.modbus_tls import SecureModbusAdapter
+
+            adapter = SecureModbusAdapter("localhost", 802, cert, key)
+            with pytest.raises(ValueError, match="bad state"):
+                adapter.validate_connection()
+
     def test_connection_failure_raises(self, tmp_path):
         cert = tmp_path / "client.pem"
         key = tmp_path / "client.key"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -164,6 +164,36 @@ class TestFastAPIEndpoints:
         assert "name" in data
         assert "n_oscillators" in data
 
+    def test_health_reports_known_runtime_error(self, monkeypatch):
+        from scpn_phase_orchestrator.server import create_app
+
+        def fail_snapshot(self):
+            raise RuntimeError("engine unavailable")
+
+        monkeypatch.setattr(SimulationState, "snapshot", fail_snapshot)
+        app = create_app(DOMAINPACK_DIR / "minimal_domain" / "binding_spec.yaml")
+        client = TestClient(app)
+
+        r = client.get("/api/health")
+
+        assert r.status_code == 200
+        data = r.json()
+        assert data["status"] == "degraded"
+        assert data["checks"]["engine"] == "error: engine unavailable"
+
+    def test_health_does_not_swallow_unexpected_fault(self, monkeypatch):
+        from scpn_phase_orchestrator.server import create_app
+
+        def fail_snapshot(self):
+            raise AssertionError("programming fault")
+
+        monkeypatch.setattr(SimulationState, "snapshot", fail_snapshot)
+        app = create_app(DOMAINPACK_DIR / "minimal_domain" / "binding_spec.yaml")
+        client = TestClient(app)
+
+        with pytest.raises(AssertionError, match="programming fault"):
+            client.get("/api/health")
+
     def test_production_requires_api_key_env(self, monkeypatch):
         from scpn_phase_orchestrator.server import create_app
 


### PR DESCRIPTION
## Summary
- replace broad health-check exception handling with explicit expected runtime/data-health exceptions
- replace broad Modbus TLS validation exception handling with connection-state exception types
- add regressions proving handled failures still degrade safely while unexpected faults propagate

## Validation
- .venv-linux/bin/ruff check src/scpn_phase_orchestrator/server.py src/scpn_phase_orchestrator/adapters/modbus_tls.py tests/test_server.py tests/test_modbus_tls.py
- .venv-linux/bin/ruff format --check src/scpn_phase_orchestrator/server.py src/scpn_phase_orchestrator/adapters/modbus_tls.py tests/test_server.py tests/test_modbus_tls.py
- .venv-linux/bin/python -m mypy src/scpn_phase_orchestrator/server.py src/scpn_phase_orchestrator/adapters/modbus_tls.py
- .venv-linux/bin/python -m pytest tests/test_server.py tests/test_modbus_tls.py
- .venv-linux/bin/python -m bandit -q src/scpn_phase_orchestrator/server.py src/scpn_phase_orchestrator/adapters/modbus_tls.py

Full repository gate is delegated to remote CI under the temporary project rule.