### PR TITLE
Type visualization array inputs

### DIFF
--- a/src/scpn_phase_orchestrator/visualization/network.py
+++ b/src/scpn_phase_orchestrator/visualization/network.py
@@ -9,15 +9,18 @@
 from __future__ import annotations
 
 import json
+from typing import TypeAlias
 
 import numpy as np
 from numpy.typing import NDArray
 
 __all__ = ["network_graph_json", "coupling_heatmap_json"]
 
+FloatArray: TypeAlias = NDArray[np.float64]
+
 
 def network_graph_json(
-    knm: NDArray,
+    knm: FloatArray,
     layer_names: list[str] | None = None,
     R_values: list[float] | None = None,
     threshold: float = 0.01,
@@ -60,7 +63,7 @@ def network_graph_json(
 
 
 def coupling_heatmap_json(
-    knm: NDArray,
+    knm: FloatArray,
     layer_names: list[str] | None = None,
 ) -> str:
     """Generate heatmap data JSON from coupling matrix.

--- a/src/scpn_phase_orchestrator/visualization/torus.py
+++ b/src/scpn_phase_orchestrator/visualization/torus.py
@@ -9,15 +9,18 @@
 from __future__ import annotations
 
 import json
+from typing import TypeAlias
 
 import numpy as np
 from numpy.typing import NDArray
 
 __all__ = ["torus_points_json", "phase_wheel_json"]
 
+FloatArray: TypeAlias = NDArray[np.float64]
+
 
 def torus_points_json(
-    phases: NDArray,
+    phases: FloatArray,
     R_values: list[float] | None = None,
     major_radius: float = 2.0,
     minor_radius: float = 0.5,
@@ -59,7 +62,7 @@ def torus_points_json(
     return json.dumps({"points": points}, indent=2)
 
 
-def phase_wheel_json(phases: NDArray, layer_names: list[str] | None = None) -> str:
+def phase_wheel_json(phases: FloatArray, layer_names: list[str] | None = None) -> str:
     """Phase wheel data: oscillator phases as polar coordinates.
 
     Each oscillator is a point at angle=θ_i, radius=1 on the unit circle.

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -9,6 +9,7 @@
 from __future__ import annotations
 
 import json
+from typing import get_type_hints
 
 import numpy as np
 
@@ -138,3 +139,18 @@ class TestVisualizationPipelineWiring:
 
         wheel = json.loads(phase_wheel_json(phases))
         assert len(wheel["oscillators"]) == n
+
+
+class TestVisualizationTypeHints:
+    """Guard the V2 typed-array contract for public visualization helpers."""
+
+    def test_public_array_inputs_use_parameterised_ndarray_aliases(self):
+        for fn, param in [
+            (network_graph_json, "knm"),
+            (coupling_heatmap_json, "knm"),
+            (torus_points_json, "phases"),
+            (phase_wheel_json, "phases"),
+        ]:
+            hint = get_type_hints(fn)[param]
+            assert "numpy.ndarray" in str(hint)
+            assert "float64" in str(hint)


### PR DESCRIPTION
## Summary
- add NDArray[np.float64] aliases for public visualization helper array inputs
- cover visualization helper annotations so the public contract does not drift back to loose NDArray

## Local validation
- .venv-linux/bin/ruff check src/scpn_phase_orchestrator/visualization/network.py src/scpn_phase_orchestrator/visualization/torus.py tests/test_visualization.py
- .venv-linux/bin/ruff format --check src/scpn_phase_orchestrator/visualization/network.py src/scpn_phase_orchestrator/visualization/torus.py tests/test_visualization.py
- .venv-linux/bin/python -m mypy src/scpn_phase_orchestrator/visualization/network.py src/scpn_phase_orchestrator/visualization/torus.py
- .venv-linux/bin/python -m pytest tests/test_visualization.py
- .venv-linux/bin/python -m bandit -q src/scpn_phase_orchestrator/visualization/network.py src/scpn_phase_orchestrator/visualization/torus.py
- git diff --check
- staged diff audit clean

Full pytest/coverage gate is delegated to remote CI per the temporary local-hardware rule.