### PR TITLE
Generalise QueueWaves service channels

### DIFF
--- a/src/scpn_phase_orchestrator/apps/queuewaves/config.py
+++ b/src/scpn_phase_orchestrator/apps/queuewaves/config.py
@@ -16,6 +16,7 @@ from urllib.parse import urlparse
 import yaml
 
 from scpn_phase_orchestrator.binding.types import (
+    VALID_EXTRACTORS,
     ActuatorMapping,
     BindingSpec,
     BoundaryDef,
@@ -24,6 +25,8 @@ from scpn_phase_orchestrator.binding.types import (
     HierarchyLayer,
     ObjectivePartition,
     OscillatorFamily,
+    is_valid_channel_id,
+    resolve_extractor_type,
 )
 
 __all__ = [
@@ -36,7 +39,7 @@ __all__ = [
 ]
 
 _LAYER_ORDER = {"micro": 0, "meso": 1, "macro": 2}
-_VALID_CHANNELS = frozenset({"P", "I"})
+_DEFAULT_EXTRACTORS_BY_CHANNEL = {"P": "hilbert", "I": "event", "S": "ring"}
 _VALID_ALERT_FORMATS = frozenset({"generic", "slack"})
 _VALID_SECURITY_MODES = frozenset({"development", "production"})
 
@@ -86,12 +89,13 @@ def _require_http_url(value: str, field_name: str) -> str:
 
 @dataclass(frozen=True)
 class ServiceDef:
-    """A monitored service: name, PromQL query, hierarchy layer, and channel type."""
+    """A monitored service: query, hierarchy layer, channel, and extractor."""
 
     name: str
     promql: str
     layer: str  # micro, meso, macro
-    channel: str = "P"  # P(hysical) or I(nformational)
+    channel: str = "P"
+    extractor_type: str | None = None
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "name", _require_non_empty(self.name, "service.name"))
@@ -100,8 +104,29 @@ class ServiceDef:
         )
         if self.layer not in _LAYER_ORDER:
             raise ValueError("service.layer must be micro, meso, or macro")
-        if self.channel not in _VALID_CHANNELS:
-            raise ValueError("service.channel must be P or I")
+        object.__setattr__(
+            self,
+            "channel",
+            _require_non_empty(self.channel, "service.channel"),
+        )
+        if not is_valid_channel_id(self.channel):
+            raise ValueError(
+                "service.channel must be a valid binding channel identifier"
+            )
+        if self.extractor_type is not None:
+            raw_extractor = _require_non_empty(
+                self.extractor_type, "service.extractor_type"
+            )
+            extractor = resolve_extractor_type(raw_extractor)
+            if extractor not in VALID_EXTRACTORS:
+                raise ValueError("service.extractor_type must be a valid extractor")
+            object.__setattr__(self, "extractor_type", extractor)
+
+    def resolved_extractor_type(self) -> str:
+        """Return the extractor algorithm for this service channel."""
+        if self.extractor_type is not None:
+            return self.extractor_type
+        return _DEFAULT_EXTRACTORS_BY_CHANNEL.get(self.channel, "hilbert")
 
 
 @dataclass(frozen=True)
@@ -266,6 +291,7 @@ def load_config(path: Path) -> QueueWavesConfig:
             promql=s["promql"],
             layer=s.get("layer", "micro"),
             channel=s.get("channel", "P"),
+            extractor_type=s.get("extractor_type"),
         )
         for s in raw.get("services", [])
     ]
@@ -338,9 +364,10 @@ class ConfigCompiler:
             )
 
             for svc in svcs:
-                ext = "hilbert" if svc.channel == "P" else "event"
                 osc_families[svc.name] = OscillatorFamily(
-                    channel=svc.channel, extractor_type=ext, config={}
+                    channel=svc.channel,
+                    extractor_type=svc.resolved_extractor_type(),
+                    config={},
                 )
 
             # micro = bad (retry storms sync), macro = good (coordinated throughput)

--- a/tests/apps/queuewaves/test_config.py
+++ b/tests/apps/queuewaves/test_config.py
@@ -217,7 +217,7 @@ def test_load_config_normalises_numeric_scalars(tmp_path: Path) -> None:
             services:
               - name: s1
                 promql: up
-                channel: X
+                channel: bad channel
             """,
             "service.channel",
         ),
@@ -267,7 +267,9 @@ def test_load_config_rejects_invalid_values(
 @pytest.mark.parametrize(
     "factory",
     [
-        lambda: ServiceDef(name="svc", promql="up", layer="micro", channel="S"),
+        lambda: ServiceDef(
+            name="svc", promql="up", layer="micro", channel="bad channel"
+        ),
         lambda: ThresholdConfig(r_bad_warn=2.0, r_bad_critical=1.0),
         lambda: CouplingConfig(strength=-0.1),
         lambda: AlertSink(url="ftp://example.com/hook"),

--- a/tests/test_queuewaves_pipeline.py
+++ b/tests/test_queuewaves_pipeline.py
@@ -9,6 +9,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 
 from scpn_phase_orchestrator.apps.queuewaves.config import (
     ConfigCompiler,
@@ -39,6 +40,59 @@ def test_compiler_produces_valid_spec():
     assert len(spec.layers) == 3
     assert spec.objectives.bad_layers == [0]
     assert 1 in spec.objectives.good_layers
+
+
+def test_compiler_preserves_named_extension_channels():
+    cfg = QueueWavesConfig(
+        prometheus_url="http://localhost:9090",
+        services=[
+            ServiceDef(name="cpu", promql="cpu", layer="micro", channel="P"),
+            ServiceDef(name="events", promql="events", layer="meso", channel="I"),
+            ServiceDef(name="state", promql="state", layer="macro", channel="S"),
+            ServiceDef(
+                name="quantum",
+                promql="quantum",
+                layer="macro",
+                channel="Q_control",
+                extractor_type="event",
+            ),
+        ],
+        scrape_interval_s=1.0,
+        buffer_length=16,
+    )
+
+    spec = ConfigCompiler().compile(cfg)
+
+    assert spec.oscillator_families["cpu"].channel == "P"
+    assert spec.oscillator_families["cpu"].extractor_type == "hilbert"
+    assert spec.oscillator_families["events"].channel == "I"
+    assert spec.oscillator_families["events"].extractor_type == "event"
+    assert spec.oscillator_families["state"].channel == "S"
+    assert spec.oscillator_families["state"].extractor_type == "ring"
+    assert spec.oscillator_families["quantum"].channel == "Q_control"
+    assert spec.oscillator_families["quantum"].extractor_type == "event"
+
+
+def test_named_extension_channel_defaults_to_hilbert_extractor():
+    svc = ServiceDef(name="custom", promql="custom", layer="micro", channel="QoS")
+
+    assert svc.resolved_extractor_type() == "hilbert"
+
+
+def test_service_rejects_invalid_channel_identifier():
+    with pytest.raises(ValueError, match="valid binding channel identifier"):
+        ServiceDef(name="bad", promql="bad", layer="micro", channel="bad channel")
+
+
+def test_service_rejects_invalid_extractor_type():
+    with pytest.raises(ValueError, match="valid extractor"):
+        ServiceDef(
+            name="bad",
+            promql="bad",
+            layer="micro",
+            channel="Q",
+            extractor_type="unsafe",
+        )
 
 
 def test_pipeline_tick():


### PR DESCRIPTION
## Summary
- allow QueueWaves services to use any valid binding channel identifier, not only P and I
- add optional service extractor_type with binding-layer alias resolution and validation
- preserve default extractors for P, I, and S; extension channels default to hilbert when not configured
- cover four-channel QueueWaves compilation and invalid config cases

## Local validation
- .venv-linux/bin/ruff check src/scpn_phase_orchestrator/apps/queuewaves/config.py tests/test_queuewaves_pipeline.py
- .venv-linux/bin/ruff format --check src/scpn_phase_orchestrator/apps/queuewaves/config.py tests/test_queuewaves_pipeline.py
- .venv-linux/bin/python -m mypy src/scpn_phase_orchestrator/apps/queuewaves/config.py
- .venv-linux/bin/python -m pytest tests/test_queuewaves_pipeline.py
- .venv-linux/bin/python -m bandit -q src/scpn_phase_orchestrator/apps/queuewaves/config.py
- git diff --check
- staged diff audit clean

Full pytest/coverage gate is delegated to remote CI per the temporary local-hardware rule.