### PR TITLE
Type autotune array contracts

### DIFF
--- a/src/scpn_phase_orchestrator/autotune/freq_id.py
+++ b/src/scpn_phase_orchestrator/autotune/freq_id.py
@@ -9,22 +9,25 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TypeAlias
 
 import numpy as np
 from numpy.typing import NDArray
 
 __all__ = ["identify_frequencies", "FrequencyResult"]
 
+FloatArray: TypeAlias = NDArray[np.float64]
+
 
 @dataclass
 class FrequencyResult:
-    frequencies: NDArray
-    amplitudes: NDArray
+    frequencies: FloatArray
+    amplitudes: FloatArray
     layer_assignment: list[int]
 
 
 def identify_frequencies(
-    data: NDArray,
+    data: FloatArray,
     fs: float,
     n_modes: int | None = None,
     rank_threshold: float = 0.01,

--- a/src/scpn_phase_orchestrator/autotune/phase_extract.py
+++ b/src/scpn_phase_orchestrator/autotune/phase_extract.py
@@ -9,6 +9,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TypeAlias
 
 import numpy as np
 from numpy.typing import NDArray
@@ -16,19 +17,21 @@ from scipy.signal import hilbert
 
 __all__ = ["extract_phases", "PhaseResult"]
 
+FloatArray: TypeAlias = NDArray[np.float64]
+
 
 @dataclass
 class PhaseResult:
     """Hilbert-transform output: instantaneous phase, amplitude, and frequency."""
 
-    phases: NDArray
-    amplitudes: NDArray
-    instantaneous_freq: NDArray
+    phases: FloatArray
+    amplitudes: FloatArray
+    instantaneous_freq: FloatArray
     dominant_freq: float
 
 
 def extract_phases(
-    signal: NDArray,
+    signal: FloatArray,
     fs: float,
     bandpass: tuple[float, float] | None = None,
 ) -> PhaseResult:
@@ -49,8 +52,8 @@ def extract_phases(
         x = _bandpass_filter(x, fs, bandpass[0], bandpass[1])
 
     analytic = hilbert(x)
-    phases: NDArray = np.angle(analytic) % (2 * np.pi)
-    amplitudes: NDArray = np.abs(analytic)
+    phases: FloatArray = np.angle(analytic) % (2 * np.pi)
+    amplitudes: FloatArray = np.abs(analytic)
 
     # Instantaneous frequency from phase derivative
     dphase = np.diff(np.unwrap(np.angle(analytic)))
@@ -69,12 +72,12 @@ def extract_phases(
     )
 
 
-def _bandpass_filter(x: NDArray, fs: float, low: float, high: float) -> NDArray:
+def _bandpass_filter(x: FloatArray, fs: float, low: float, high: float) -> FloatArray:
     """Simple FFT-based bandpass filter."""
     n = len(x)
     freqs = np.fft.rfftfreq(n, d=1.0 / fs)
     fft = np.fft.rfft(x)
     mask = (freqs >= low) & (freqs <= high)
     fft[~mask] = 0.0
-    result: NDArray = np.fft.irfft(fft, n=n)
+    result: FloatArray = np.fft.irfft(fft, n=n)
     return result

--- a/src/scpn_phase_orchestrator/autotune/pipeline.py
+++ b/src/scpn_phase_orchestrator/autotune/pipeline.py
@@ -9,6 +9,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TypeAlias
 
 import numpy as np
 from numpy.typing import NDArray
@@ -19,21 +20,23 @@ from scpn_phase_orchestrator.coupling.prior import UniversalPrior
 
 __all__ = ["identify_binding_spec", "AutoTuneResult"]
 
+FloatArray: TypeAlias = NDArray[np.float64]
+
 
 @dataclass
 class AutoTuneResult:
     """Output of the auto-tune pipeline: inferred frequencies and coupling."""
 
     omegas: list[float]
-    knm: NDArray
-    alpha: NDArray
+    knm: FloatArray
+    alpha: FloatArray
     n_layers: int
     dominant_freqs: list[float]
     K_c_estimate: float
 
 
 def identify_binding_spec(
-    time_series: NDArray,
+    time_series: FloatArray,
     fs: float,
     n_layers: int | None = None,
 ) -> AutoTuneResult:

--- a/tests/test_autotune_pipeline.py
+++ b/tests/test_autotune_pipeline.py
@@ -8,8 +8,15 @@
 
 from __future__ import annotations
 
+from typing import get_type_hints
+
 import numpy as np
 
+from scpn_phase_orchestrator.autotune.freq_id import (
+    FrequencyResult,
+    identify_frequencies,
+)
+from scpn_phase_orchestrator.autotune.phase_extract import PhaseResult, extract_phases
 from scpn_phase_orchestrator.autotune.pipeline import (
     AutoTuneResult,
     identify_binding_spec,
@@ -98,3 +105,29 @@ class TestAutoTunePipelineWiring:
             )
         r, _ = compute_order_parameter(phases)
         assert 0.0 <= r <= 1.0
+
+
+class TestAutoTuneTypeHints:
+    """Guard the V2 typed-array contract for public autotune helpers."""
+
+    def test_public_array_inputs_use_parameterised_ndarray_aliases(self):
+        for fn, param in [
+            (extract_phases, "signal"),
+            (identify_frequencies, "data"),
+            (identify_binding_spec, "time_series"),
+        ]:
+            hint = get_type_hints(fn)[param]
+            assert "numpy.ndarray" in str(hint)
+            assert "float64" in str(hint)
+
+    def test_public_result_arrays_use_parameterised_ndarray_aliases(self):
+        for cls, fields in [
+            (PhaseResult, ["phases", "amplitudes", "instantaneous_freq"]),
+            (FrequencyResult, ["frequencies", "amplitudes"]),
+            (AutoTuneResult, ["knm", "alpha"]),
+        ]:
+            hints = get_type_hints(cls)
+            for field in fields:
+                hint = hints[field]
+                assert "numpy.ndarray" in str(hint)
+                assert "float64" in str(hint)


### PR DESCRIPTION
## Summary
- add NDArray[np.float64] aliases for public autotune helper inputs
- parameterise autotune result dataclass array fields
- add annotation drift coverage for phase extraction, frequency ID, and binding auto-tune helpers

## Local validation
- .venv-linux/bin/ruff check src/scpn_phase_orchestrator/autotune/phase_extract.py src/scpn_phase_orchestrator/autotune/freq_id.py src/scpn_phase_orchestrator/autotune/pipeline.py tests/test_autotune_pipeline.py
- .venv-linux/bin/ruff format --check src/scpn_phase_orchestrator/autotune/phase_extract.py src/scpn_phase_orchestrator/autotune/freq_id.py src/scpn_phase_orchestrator/autotune/pipeline.py tests/test_autotune_pipeline.py
- .venv-linux/bin/python -m mypy src/scpn_phase_orchestrator/autotune/phase_extract.py src/scpn_phase_orchestrator/autotune/freq_id.py src/scpn_phase_orchestrator/autotune/pipeline.py
- .venv-linux/bin/python -m pytest tests/test_phase_extract.py tests/test_freq_id.py tests/test_autotune_pipeline.py
- .venv-linux/bin/python -m bandit -q src/scpn_phase_orchestrator/autotune/phase_extract.py src/scpn_phase_orchestrator/autotune/freq_id.py src/scpn_phase_orchestrator/autotune/pipeline.py
- git diff --check
- staged diff audit clean

Full pytest/coverage gate is delegated to remote CI per the temporary local-hardware rule.