### PR TITLE
Type oscillator array contracts

### DIFF
--- a/docs/reference/api/oscillators.md
+++ b/docs/reference/api/oscillators.md
@@ -1,10 +1,11 @@
 # Oscillators
 
-Phase extraction from raw signals via three channels: Physical (P),
-Informational (I), Symbolic (S). This three-channel decomposition is
-the core abstraction that makes SPO domain-agnostic — any signal
-that exhibits periodic or quasi-periodic behaviour maps onto one or
-more channels.
+Phase extraction from raw signals via canonical Physical (P),
+Informational (I), and Symbolic (S) channels, plus named extension
+channels. The P/I/S decomposition is the default abstraction that makes
+SPO domain-agnostic, but deployments are not limited to three channels:
+any signal that exhibits periodic or quasi-periodic behaviour can map
+onto one or more named channels.
 
 ## Pipeline position
 
@@ -32,7 +33,8 @@ Quality scores gate which oscillators participate in coupling.
 
 ## The PIS Model
 
-Every domain signal decomposes into at most three oscillator channels:
+Every domain signal decomposes into one or more oscillator channels. The
+canonical channels are:
 
 | Channel | Signal type | Extraction method | Example domains |
 |---------|------------|-------------------|-----------------|
@@ -40,9 +42,12 @@ Every domain signal decomposes into at most three oscillator channels:
 | **I** (Informational) | Event streams, rates | Inter-event interval | Network traffic, API calls, manufacturing |
 | **S** (Symbolic) | Categorical sequences | Ring mapping | Protocols, language, music, genetics |
 
-Not every domain uses all three channels. A pure physics domain (tokamak
-plasma) might use only P. A pure IT domain (microservices) might use
-only I. The binding specification declares which channels are active.
+Not every domain uses all three canonical channels. A pure physics
+domain (tokamak plasma) might use only P. A pure IT domain
+(microservices) might use only I. Larger deployments can add named
+extension channels such as `thermal`, `market_sentiment`, or
+`operator_intent` while preserving the same `PhaseState` contract. The
+binding specification declares which channels are active.
 
 ---
 
@@ -69,9 +74,14 @@ are downweighted in coupling and excluded from regime classification.
 All channel extractors implement the `PhaseExtractor` abstract base class:
 
 ```python
+from numpy.typing import NDArray
+import numpy as np
+
+FloatArray = NDArray[np.float64]
+
 class PhaseExtractor(ABC):
     @abstractmethod
-    def extract(self, signal: NDArray, sample_rate: float) -> list[PhaseState]: ...
+    def extract(self, signal: FloatArray, sample_rate: float) -> list[PhaseState]: ...
 
     @abstractmethod
     def quality_score(self, phase_states: list[PhaseState]) -> float: ...
@@ -214,7 +224,7 @@ Cumulative transition distances normalised to [0, 2π).
 |--------|-----------|-------------|
 | `score` | `(states) → float` | Amplitude-weighted mean quality |
 | `detect_collapse` | `(states, threshold=0.1) → bool` | True if >50% below threshold |
-| `downweight_mask` | `(states, min_quality=0.3) → NDArray` | Weight array, zeros below min |
+| `downweight_mask` | `(states, min_quality=0.3) → NDArray[np.float64]` | Weight array, zeros below min |
 
 ### Downweight mask in pipeline
 

--- a/src/scpn_phase_orchestrator/oscillators/base.py
+++ b/src/scpn_phase_orchestrator/oscillators/base.py
@@ -10,10 +10,14 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from typing import TypeAlias
 
+import numpy as np
 from numpy.typing import NDArray
 
 __all__ = ["PhaseState", "PhaseExtractor"]
+
+FloatArray: TypeAlias = NDArray[np.float64]
 
 
 @dataclass
@@ -32,7 +36,7 @@ class PhaseExtractor(ABC):
     """Abstract base for signal-to-phase extraction algorithms."""
 
     @abstractmethod
-    def extract(self, signal: NDArray, sample_rate: float) -> list[PhaseState]:
+    def extract(self, signal: FloatArray, sample_rate: float) -> list[PhaseState]:
         """Extract phase states from a raw signal at the given sample rate."""
         ...
 

--- a/src/scpn_phase_orchestrator/oscillators/informational.py
+++ b/src/scpn_phase_orchestrator/oscillators/informational.py
@@ -8,6 +8,8 @@
 
 from __future__ import annotations
 
+from typing import TypeAlias
+
 import numpy as np
 from numpy.typing import NDArray
 
@@ -15,6 +17,8 @@ from scpn_phase_orchestrator._compat import TWO_PI
 from scpn_phase_orchestrator.oscillators.base import PhaseExtractor, PhaseState
 
 __all__ = ["InformationalExtractor"]
+
+FloatArray: TypeAlias = NDArray[np.float64]
 
 
 class InformationalExtractor(PhaseExtractor):
@@ -27,7 +31,7 @@ class InformationalExtractor(PhaseExtractor):
     def __init__(self, node_id: str = "info_0"):
         self._node_id = node_id
 
-    def extract(self, signal: NDArray, sample_rate: float) -> list[PhaseState]:
+    def extract(self, signal: FloatArray, sample_rate: float) -> list[PhaseState]:
         """Args:
         signal: 1-D array of event timestamps in seconds (sorted ascending).
         sample_rate: not used for timestamps but kept for interface consistency.

--- a/src/scpn_phase_orchestrator/oscillators/init_phases.py
+++ b/src/scpn_phase_orchestrator/oscillators/init_phases.py
@@ -8,6 +8,8 @@
 
 from __future__ import annotations
 
+from typing import TypeAlias
+
 import numpy as np
 from numpy.typing import NDArray
 
@@ -18,6 +20,8 @@ from scpn_phase_orchestrator.oscillators.symbolic import SymbolicExtractor
 
 __all__ = ["extract_initial_phases"]
 
+FloatArray: TypeAlias = NDArray[np.float64]
+
 TWO_PI = 2.0 * np.pi
 _PHYSICAL_EXTRACTORS = frozenset({"hilbert", "wavelet", "zero_crossing"})
 _INFORMATIONAL_EXTRACTORS = frozenset({"event"})
@@ -26,9 +30,9 @@ _SYMBOLIC_EXTRACTORS = frozenset({"ring", "graph"})
 
 def extract_initial_phases(
     spec: BindingSpec,
-    omegas: NDArray,
+    omegas: FloatArray,
     seed: int = 42,
-) -> NDArray:
+) -> FloatArray:
     """Extract initial phases from channels defined in binding_spec.
 
     For each oscillator, generates a synthetic signal matching the family

--- a/src/scpn_phase_orchestrator/oscillators/physical.py
+++ b/src/scpn_phase_orchestrator/oscillators/physical.py
@@ -8,6 +8,8 @@
 
 from __future__ import annotations
 
+from typing import TypeAlias
+
 import numpy as np
 from numpy.typing import NDArray
 
@@ -17,6 +19,9 @@ from scpn_phase_orchestrator.oscillators.base import PhaseExtractor, PhaseState
 
 __all__ = ["PhysicalExtractor"]
 
+FloatArray: TypeAlias = NDArray[np.float64]
+ComplexArray: TypeAlias = NDArray[np.complex128]
+
 
 class PhysicalExtractor(PhaseExtractor):
     """Extracts instantaneous phase from continuous waveforms via Hilbert transform."""
@@ -24,7 +29,7 @@ class PhysicalExtractor(PhaseExtractor):
     def __init__(self, node_id: str = "phys_0"):
         self._node_id = node_id
 
-    def extract(self, signal: NDArray, sample_rate: float) -> list[PhaseState]:
+    def extract(self, signal: FloatArray, sample_rate: float) -> list[PhaseState]:
         """Extract instantaneous phase from a 1-D waveform via Hilbert transform."""
         if signal.ndim != 1 or signal.size < 2:
             raise ValueError(
@@ -71,7 +76,7 @@ class PhysicalExtractor(PhaseExtractor):
         return float(np.mean([ps.quality for ps in phase_states]))
 
     @staticmethod
-    def _envelope_quality(signal: NDArray, analytic: NDArray) -> float:
+    def _envelope_quality(signal: FloatArray, analytic: ComplexArray) -> float:
         envelope = np.abs(analytic)
         mean_env = np.mean(envelope)
         if mean_env < 1e-15:

--- a/src/scpn_phase_orchestrator/oscillators/quality.py
+++ b/src/scpn_phase_orchestrator/oscillators/quality.py
@@ -8,12 +8,16 @@
 
 from __future__ import annotations
 
+from typing import TypeAlias
+
 import numpy as np
 from numpy.typing import NDArray
 
 from scpn_phase_orchestrator.oscillators.base import PhaseState
 
 __all__ = ["PhaseQualityScorer"]
+
+FloatArray: TypeAlias = NDArray[np.float64]
 
 
 class PhaseQualityScorer:
@@ -40,7 +44,7 @@ class PhaseQualityScorer:
 
     def downweight_mask(
         self, phase_states: list[PhaseState], min_quality: float = 0.3
-    ) -> NDArray:
+    ) -> FloatArray:
         """Weight array in [0,1], zeros below min_quality."""
         if not phase_states:
             return np.array([], dtype=np.float64)

--- a/src/scpn_phase_orchestrator/oscillators/symbolic.py
+++ b/src/scpn_phase_orchestrator/oscillators/symbolic.py
@@ -8,6 +8,8 @@
 
 from __future__ import annotations
 
+from typing import TypeAlias
+
 import numpy as np
 from numpy.typing import NDArray
 
@@ -15,6 +17,9 @@ from scpn_phase_orchestrator._compat import TWO_PI
 from scpn_phase_orchestrator.oscillators.base import PhaseExtractor, PhaseState
 
 __all__ = ["SymbolicExtractor"]
+
+FloatArray: TypeAlias = NDArray[np.float64]
+IntArray: TypeAlias = NDArray[np.int64]
 
 
 class SymbolicExtractor(PhaseExtractor):
@@ -39,7 +44,7 @@ class SymbolicExtractor(PhaseExtractor):
         self._node_id = node_id
         self._mode = mode
 
-    def extract(self, signal: NDArray, sample_rate: float) -> list[PhaseState]:
+    def extract(self, signal: FloatArray, sample_rate: float) -> list[PhaseState]:
         """Map discrete state indices to phases on the unit circle."""
         indices = np.asarray(signal, dtype=np.int64)
         if self._mode == "ring":
@@ -84,7 +89,7 @@ class SymbolicExtractor(PhaseExtractor):
             return 0.0
         return float(np.mean([ps.quality for ps in phase_states]))
 
-    def _transition_quality(self, indices: NDArray, i: int) -> float:
+    def _transition_quality(self, indices: IntArray, i: int) -> float:
         """Quality based on transition regularity: penalise repeated or large jumps."""
         if i == 0 or len(indices) < 2:
             return 0.5

--- a/tests/test_oscillator_base.py
+++ b/tests/test_oscillator_base.py
@@ -8,10 +8,17 @@
 
 from __future__ import annotations
 
+from typing import get_type_hints
+
 import numpy as np
 import pytest
 
 from scpn_phase_orchestrator.oscillators.base import PhaseExtractor, PhaseState
+from scpn_phase_orchestrator.oscillators.informational import InformationalExtractor
+from scpn_phase_orchestrator.oscillators.init_phases import extract_initial_phases
+from scpn_phase_orchestrator.oscillators.physical import PhysicalExtractor
+from scpn_phase_orchestrator.oscillators.quality import PhaseQualityScorer
+from scpn_phase_orchestrator.oscillators.symbolic import SymbolicExtractor
 
 # ── PhaseState construction and field access ────────────────────────────
 
@@ -292,6 +299,23 @@ class TestPhaseExtractorContract:
     def test_quality_score_is_abstract(self):
         """quality_score must be marked @abstractmethod."""
         assert getattr(PhaseExtractor.quality_score, "__isabstractmethod__", False)
+
+    def test_public_array_contracts_are_parameterised(self):
+        """Public oscillator array contracts stay element-typed."""
+        for fn, param in [
+            (PhaseExtractor.extract, "signal"),
+            (PhysicalExtractor.extract, "signal"),
+            (InformationalExtractor.extract, "signal"),
+            (SymbolicExtractor.extract, "signal"),
+            (extract_initial_phases, "omegas"),
+        ]:
+            hint = get_type_hints(fn)[param]
+            assert "numpy.ndarray" in str(hint)
+            assert "float64" in str(hint)
+
+        result_hint = get_type_hints(PhaseQualityScorer.downweight_mask)["return"]
+        assert "numpy.ndarray" in str(result_hint)
+        assert "float64" in str(result_hint)
 
 
 # ── PhaseState edge values ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add NDArray[np.float64] aliases for public oscillator extractor inputs
- parameterise initial phase extraction and quality mask array contracts
- keep symbolic transition indices typed as int64 internally
- add annotation drift coverage for oscillator public contracts

## Local validation
- .venv-linux/bin/ruff check on changed source/test files
- .venv-linux/bin/ruff format --check on changed source/test files
- .venv-linux/bin/python -m mypy on changed oscillator source files
- .venv-linux/bin/python -m pytest tests/test_oscillator_base.py tests/test_oscillator_physical.py tests/test_oscillator_informational.py tests/test_oscillator_symbolic.py tests/test_quality_scorer.py tests/test_init_phases.py
- .venv-linux/bin/python -m bandit -q on changed source files
- git diff --check
- staged diff audit clean

Full pytest/coverage gate is delegated to remote CI per the temporary local-hardware rule.