### PR TITLE
Validate Prometheus adapter config

### DIFF
--- a/src/scpn_phase_orchestrator/adapters/prometheus.py
+++ b/src/scpn_phase_orchestrator/adapters/prometheus.py
@@ -9,7 +9,9 @@
 from __future__ import annotations
 
 import json
+from math import isfinite
 from urllib.error import URLError
+from urllib.parse import urlparse
 from urllib.request import Request, urlopen
 
 import numpy as np
@@ -20,8 +22,21 @@ class PrometheusAdapter:
     """Fetch time-series metrics from a Prometheus endpoint."""
 
     def __init__(self, endpoint: str, timeout: float = 10.0):
+        if not isinstance(endpoint, str) or not endpoint:
+            raise ValueError("Prometheus endpoint must be a non-empty http(s) URL")
+        parsed = urlparse(endpoint)
+        if parsed.scheme not in ("http", "https") or not parsed.netloc:
+            raise ValueError("Prometheus endpoint must be a non-empty http(s) URL")
+        if isinstance(timeout, bool):
+            raise ValueError("Prometheus timeout must be finite and positive")
+        try:
+            parsed_timeout = float(timeout)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("Prometheus timeout must be finite and positive") from exc
+        if not isfinite(parsed_timeout) or parsed_timeout <= 0.0:
+            raise ValueError("Prometheus timeout must be finite and positive")
         self._endpoint = endpoint.rstrip("/")
-        self._timeout = timeout
+        self._timeout = parsed_timeout
 
     def fetch_metric(
         self, query: str, start: float, end: float, step: float

--- a/tests/test_prometheus.py
+++ b/tests/test_prometheus.py
@@ -28,6 +28,22 @@ def _mock_response(body: dict):
     return resp
 
 
+class TestPrometheusConfigValidation:
+    @pytest.mark.parametrize("endpoint", ["", "localhost:9090", "file:///tmp/prom"])
+    def test_endpoint_must_be_http_url(self, endpoint: str):
+        with pytest.raises(ValueError, match="endpoint"):
+            PrometheusAdapter(endpoint)
+
+    @pytest.mark.parametrize("timeout", [0.0, -1.0, float("inf"), float("nan"), True])
+    def test_timeout_must_be_finite_and_positive(self, timeout: float):
+        with pytest.raises(ValueError, match="timeout"):
+            PrometheusAdapter("http://localhost:9090", timeout=timeout)
+
+    def test_timeout_is_normalised_to_float(self):
+        adapter = PrometheusAdapter("http://localhost:9090", timeout=1)
+        assert adapter._timeout == 1.0
+
+
 class TestFetchMetric:
     def test_returns_values(self):
         body = {


### PR DESCRIPTION
## Summary
- reject invalid Prometheus adapter endpoint schemes before network use
- reject boolean, zero, negative, and non-finite timeout values
- normalise accepted timeout values to float
- add focused regression coverage for the U1 configuration validation backlog

## Local validation
- .venv-linux/bin/ruff check src/scpn_phase_orchestrator/adapters/prometheus.py tests/test_prometheus.py
- .venv-linux/bin/ruff format --check src/scpn_phase_orchestrator/adapters/prometheus.py tests/test_prometheus.py
- .venv-linux/bin/python -m mypy src/scpn_phase_orchestrator/adapters/prometheus.py
- .venv-linux/bin/python -m pytest tests/test_prometheus.py tests/test_adapters_coverage.py::TestPrometheusAdapter
- .venv-linux/bin/python -m bandit -q src/scpn_phase_orchestrator/adapters/prometheus.py
- git diff --check
- staged diff audit clean

Full pytest/coverage gate is delegated to remote CI per the temporary local-hardware rule.