### PR TITLE
Validate quantum bridge Trotter order

### DIFF
--- a/src/scpn_phase_orchestrator/adapters/quantum_control_bridge.py
+++ b/src/scpn_phase_orchestrator/adapters/quantum_control_bridge.py
@@ -8,6 +8,7 @@
 
 from __future__ import annotations
 
+from numbers import Integral
 from typing import cast
 
 import numpy as np
@@ -33,8 +34,12 @@ class QuantumControlBridge:
     def __init__(self, n_oscillators: int, trotter_order: int = 1):
         if n_oscillators < 1:
             raise ValueError(f"n_oscillators must be >= 1, got {n_oscillators}")
+        if isinstance(trotter_order, bool) or not isinstance(trotter_order, Integral):
+            raise ValueError("trotter_order must be an integer >= 1")
+        if trotter_order < 1:
+            raise ValueError("trotter_order must be an integer >= 1")
         self._n = n_oscillators
-        self._trotter_order = trotter_order
+        self._trotter_order: int = int(trotter_order)
 
     def import_artifact(self, artifact_dict: dict) -> UPDEState:
         """Convert a scpn-quantum-control result dict into UPDEState."""

--- a/tests/test_quantum_bridge.py
+++ b/tests/test_quantum_bridge.py
@@ -6,6 +6,8 @@
 # Contact: www.anulum.li | protoscience@anulum.li
 # SCPN Phase Orchestrator — Quantum Bridge tests
 
+from typing import Any, cast
+
 import numpy as np
 import pytest
 
@@ -60,6 +62,14 @@ class TestConstructorValidation:
     def test_custom_trotter_order_propagates(self):
         b = QuantumControlBridge(n_oscillators=2, trotter_order=4)
         assert b._trotter_order == 4
+
+    @pytest.mark.parametrize("trotter_order", [0, -1, 1.5, "2", True])
+    def test_rejects_invalid_trotter_order(self, trotter_order: object):
+        with pytest.raises(ValueError, match="trotter_order"):
+            QuantumControlBridge(
+                n_oscillators=2,
+                trotter_order=cast("Any", trotter_order),
+            )
 
 
 class TestImportArtifactEdges:


### PR DESCRIPTION
## Summary
- reject non-integer, boolean, zero, and negative QuantumControlBridge trotter_order values
- normalise accepted Trotter orders to plain int
- add focused regression coverage for the U1 configuration-validation backlog

## Local validation
- .venv-linux/bin/ruff check src/scpn_phase_orchestrator/adapters/quantum_control_bridge.py tests/test_quantum_bridge.py tests/test_quantum_control_bridge.py
- .venv-linux/bin/ruff format --check src/scpn_phase_orchestrator/adapters/quantum_control_bridge.py tests/test_quantum_bridge.py tests/test_quantum_control_bridge.py
- .venv-linux/bin/python -m mypy src/scpn_phase_orchestrator/adapters/quantum_control_bridge.py
- .venv-linux/bin/python -m pytest tests/test_quantum_bridge.py tests/test_quantum_control_bridge.py tests/test_coverage_gaps.py::TestQuantumControlBridge
- .venv-linux/bin/python -m bandit -q src/scpn_phase_orchestrator/adapters/quantum_control_bridge.py
- git diff --check
- staged diff audit clean

Full pytest/coverage gate is delegated to remote CI per the temporary local-hardware rule.