### PR TITLE
Validate SINDy constructor config

### DIFF
--- a/src/scpn_phase_orchestrator/autotune/sindy.py
+++ b/src/scpn_phase_orchestrator/autotune/sindy.py
@@ -8,6 +8,9 @@
 
 from __future__ import annotations
 
+from math import isfinite
+from numbers import Integral, Real
+
 import numpy as np
 from scipy.linalg import lstsq
 
@@ -32,12 +35,18 @@ class PhaseSINDy:
     """
 
     def __init__(self, threshold: float = 0.05, max_iter: int = 10):
-        if threshold < 0.0:
-            raise ValueError(f"threshold must be non-negative, got {threshold}")
+        if isinstance(threshold, bool) or not isinstance(threshold, Real):
+            raise ValueError("threshold must be finite and non-negative")
+        parsed_threshold = float(threshold)
+        if not isfinite(parsed_threshold) or parsed_threshold < 0.0:
+            raise ValueError("threshold must be non-negative and finite")
+        if isinstance(max_iter, bool) or not isinstance(max_iter, Integral):
+            raise ValueError("max_iter must be an integer >= 1")
         if max_iter < 1:
             raise ValueError(f"max_iter must be >= 1, got {max_iter}")
-        self.threshold = threshold
-        self.max_iter = max_iter
+        parsed_max_iter = int(max_iter)
+        self.threshold: float = parsed_threshold
+        self.max_iter: int = parsed_max_iter
         self.coefficients: list[np.ndarray] = []
         self.feature_names: list[list[str]] = []
 

--- a/tests/test_sindy.py
+++ b/tests/test_sindy.py
@@ -9,11 +9,13 @@
 """Coverage for the Phase-SINDy symbolic coupling discoverer.
 
 The pre-existing single happy-path case exercised recovery on a clean
-two-oscillator signal. This suite adds the edge and error paths Gemini
-S6 flagged as missing.
+two-oscillator signal. This suite adds the edge and error paths flagged
+by the S6 audit.
 """
 
 from __future__ import annotations
+
+from typing import Any, cast
 
 import numpy as np
 import pytest
@@ -120,8 +122,22 @@ def test_sindy_rejects_zero_max_iter():
 
 def test_sindy_rejects_negative_threshold():
     """Negative threshold would invert the sparsification logic."""
-    with pytest.raises(ValueError, match="threshold must be non-negative"):
+    with pytest.raises(ValueError, match="threshold.*non-negative"):
         PhaseSINDy(threshold=-0.1)
+
+
+@pytest.mark.parametrize("threshold", [float("nan"), float("inf"), True, "0.1"])
+def test_sindy_rejects_non_finite_or_non_numeric_threshold(threshold: object):
+    """Threshold must be a finite numeric sparsity bound."""
+    with pytest.raises(ValueError, match="threshold"):
+        PhaseSINDy(threshold=cast(Any, threshold))
+
+
+@pytest.mark.parametrize("max_iter", [1.5, "2", True])
+def test_sindy_rejects_non_integer_max_iter(max_iter: object):
+    """STLSQ iterations must be a positive integer count."""
+    with pytest.raises(ValueError, match="max_iter"):
+        PhaseSINDy(max_iter=cast(Any, max_iter))
 
 
 def test_sindy_threshold_sparsifies_weak_terms():


### PR DESCRIPTION
## Summary
- reject non-numeric, boolean, non-finite, and negative PhaseSINDy thresholds
- reject non-integer, boolean, zero, and negative max_iter values
- normalise accepted thresholds to float and iteration counts to int
- add focused regression coverage for the U1 configuration-validation backlog
- remove an existing public test docstring agent-name mention while touching the file

## Local validation
- .venv-linux/bin/ruff check src/scpn_phase_orchestrator/autotune/sindy.py tests/test_sindy.py tests/test_config_validation_misc.py
- .venv-linux/bin/ruff format --check src/scpn_phase_orchestrator/autotune/sindy.py tests/test_sindy.py tests/test_config_validation_misc.py
- .venv-linux/bin/python -m mypy src/scpn_phase_orchestrator/autotune/sindy.py
- .venv-linux/bin/python -m pytest tests/test_sindy.py tests/test_config_validation_misc.py
- .venv-linux/bin/python -m bandit -q src/scpn_phase_orchestrator/autotune/sindy.py
- git diff --check
- staged diff audit clean

Full pytest/coverage gate is delegated to remote CI per the temporary local-hardware rule.