### PR TITLE
Validate Psi driver config

### DIFF
--- a/src/scpn_phase_orchestrator/drivers/psi_informational.py
+++ b/src/scpn_phase_orchestrator/drivers/psi_informational.py
@@ -8,6 +8,8 @@
 
 from __future__ import annotations
 
+from math import isfinite
+
 from numpy.typing import NDArray
 
 from scpn_phase_orchestrator._compat import TWO_PI
@@ -19,9 +21,15 @@ class InformationalDriver:
     """External drive Psi_I(t) = 2*pi*cadence_hz*t (mod 2*pi)."""
 
     def __init__(self, cadence_hz: float):
-        if cadence_hz <= 0.0:
-            raise ValueError(f"cadence_hz must be positive, got {cadence_hz}")
-        self._cadence_hz = cadence_hz
+        try:
+            parsed_cadence = float(cadence_hz)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("cadence_hz must be finite and positive") from exc
+        if not isfinite(parsed_cadence) or parsed_cadence <= 0.0:
+            raise ValueError(
+                f"cadence_hz must be finite and positive, got {cadence_hz}"
+            )
+        self._cadence_hz = parsed_cadence
 
     def compute(self, t: float) -> float:
         """Return Psi_I at time *t*, wrapped to [0, 2*pi)."""

--- a/src/scpn_phase_orchestrator/drivers/psi_physical.py
+++ b/src/scpn_phase_orchestrator/drivers/psi_physical.py
@@ -8,6 +8,8 @@
 
 from __future__ import annotations
 
+from math import isfinite
+
 import numpy as np
 from numpy.typing import NDArray
 
@@ -20,10 +22,19 @@ class PhysicalDriver:
     """Sinusoidal external drive: Psi_P(t) = amplitude * sin(2*pi*frequency*t)."""
 
     def __init__(self, frequency: float, amplitude: float = 1.0):
-        if frequency <= 0.0:
-            raise ValueError(f"frequency must be positive, got {frequency}")
-        self._frequency = frequency
-        self._amplitude = amplitude
+        try:
+            parsed_frequency = float(frequency)
+            parsed_amplitude = float(amplitude)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("frequency and amplitude must be finite numbers") from exc
+        if not isfinite(parsed_frequency) or parsed_frequency <= 0.0:
+            raise ValueError(f"frequency must be finite and positive, got {frequency}")
+        if not isfinite(parsed_amplitude) or parsed_amplitude < 0.0:
+            raise ValueError(
+                f"amplitude must be finite and non-negative, got {amplitude}"
+            )
+        self._frequency = parsed_frequency
+        self._amplitude = parsed_amplitude
 
     def compute(self, t: float) -> float:
         """Return Psi_P at time *t*."""

--- a/src/scpn_phase_orchestrator/drivers/psi_symbolic.py
+++ b/src/scpn_phase_orchestrator/drivers/psi_symbolic.py
@@ -20,8 +20,13 @@ class SymbolicDriver:
     def __init__(self, sequence: list[float]):
         if not sequence:
             raise ValueError("sequence must be non-empty")
-        self._sequence = np.asarray(sequence, dtype=np.float64)
-        self._n = len(sequence)
+        parsed_sequence = np.asarray(sequence, dtype=np.float64)
+        if parsed_sequence.ndim != 1:
+            raise ValueError("sequence must be one-dimensional")
+        if not np.all(np.isfinite(parsed_sequence)):
+            raise ValueError("sequence values must be finite")
+        self._sequence = parsed_sequence
+        self._n = len(parsed_sequence)
 
     def compute(self, step: int) -> float:
         """Return symbolic phase at discrete *step* (cyclic)."""

--- a/tests/test_drivers.py
+++ b/tests/test_drivers.py
@@ -8,6 +8,8 @@
 
 from __future__ import annotations
 
+from typing import Any, cast
+
 import numpy as np
 import pytest
 
@@ -75,6 +77,20 @@ class TestPhysicalDriver:
         with pytest.raises(ValueError, match="positive"):
             PhysicalDriver(frequency=0.0)
 
+    @pytest.mark.parametrize("frequency", [float("nan"), float("inf"), "fast"])
+    def test_invalid_frequency_rejected(self, frequency: object):
+        with pytest.raises(ValueError, match="frequency"):
+            PhysicalDriver(frequency=cast(Any, frequency))
+
+    @pytest.mark.parametrize("amplitude", [float("nan"), float("inf"), -0.1, "loud"])
+    def test_invalid_amplitude_rejected(self, amplitude: object):
+        with pytest.raises(ValueError, match="amplitude|frequency"):
+            PhysicalDriver(frequency=1.0, amplitude=cast(Any, amplitude))
+
+    def test_zero_amplitude_is_valid_quiescent_drive(self):
+        drv = PhysicalDriver(frequency=1.0, amplitude=0.0)
+        assert drv.compute(0.25) == pytest.approx(0.0)
+
     def test_output_bounded_by_amplitude(self):
         """Output must always be in [-amplitude, +amplitude]."""
         drv = PhysicalDriver(frequency=7.3, amplitude=2.5)
@@ -129,6 +145,11 @@ class TestInformationalDriver:
         with pytest.raises(ValueError, match="positive"):
             InformationalDriver(cadence_hz=-1.0)
 
+    @pytest.mark.parametrize("cadence_hz", [float("nan"), float("inf"), "fast"])
+    def test_invalid_cadence_rejected(self, cadence_hz: object):
+        with pytest.raises(ValueError, match="cadence_hz"):
+            InformationalDriver(cadence_hz=cast(Any, cadence_hz))
+
 
 # ---------------------------------------------------------------------------
 # SymbolicDriver: periodic sequence
@@ -167,6 +188,15 @@ class TestSymbolicDriver:
     def test_empty_sequence_rejected(self):
         with pytest.raises(ValueError, match="non-empty"):
             SymbolicDriver(sequence=[])
+
+    @pytest.mark.parametrize("sequence", [[0.0, float("nan")], [0.0, float("inf")]])
+    def test_non_finite_sequence_rejected(self, sequence: list[float]):
+        with pytest.raises(ValueError, match="finite"):
+            SymbolicDriver(sequence=sequence)
+
+    def test_multidimensional_sequence_rejected(self):
+        with pytest.raises(ValueError, match="one-dimensional"):
+            SymbolicDriver(sequence=cast(Any, [[0.0], [1.0]]))
 
     def test_batch_periodicity(self):
         """Batch output must be periodic with period = len(sequence)."""


### PR DESCRIPTION
## Summary
- reject non-finite and non-positive physical drive frequencies
- reject non-finite and negative physical drive amplitudes while preserving zero-amplitude quiescent drive
- reject non-finite and non-positive informational cadences
- reject non-finite or multi-dimensional symbolic driver sequences
- add focused regression coverage for the U1 configuration-validation backlog

## Local validation
- .venv-linux/bin/ruff check src/scpn_phase_orchestrator/drivers/psi_physical.py src/scpn_phase_orchestrator/drivers/psi_informational.py src/scpn_phase_orchestrator/drivers/psi_symbolic.py tests/test_drivers.py tests/test_drivers_oscillators.py
- .venv-linux/bin/ruff format --check src/scpn_phase_orchestrator/drivers/psi_physical.py src/scpn_phase_orchestrator/drivers/psi_informational.py src/scpn_phase_orchestrator/drivers/psi_symbolic.py tests/test_drivers.py tests/test_drivers_oscillators.py
- .venv-linux/bin/python -m mypy src/scpn_phase_orchestrator/drivers/psi_physical.py src/scpn_phase_orchestrator/drivers/psi_informational.py src/scpn_phase_orchestrator/drivers/psi_symbolic.py
- .venv-linux/bin/python -m pytest tests/test_drivers.py tests/test_drivers_oscillators.py
- .venv-linux/bin/python -m bandit -q src/scpn_phase_orchestrator/drivers/psi_physical.py src/scpn_phase_orchestrator/drivers/psi_informational.py src/scpn_phase_orchestrator/drivers/psi_symbolic.py
- git diff --check
- staged diff audit clean

Full pytest/coverage gate is delegated to remote CI per the temporary local-hardware rule.