### PR TITLE
Validate observability names

### DIFF
--- a/src/scpn_phase_orchestrator/adapters/metrics_exporter.py
+++ b/src/scpn_phase_orchestrator/adapters/metrics_exporter.py
@@ -8,15 +8,24 @@
 
 from __future__ import annotations
 
+import re
+
 from scpn_phase_orchestrator.upde.metrics import UPDEState
 
 __all__ = ["MetricsExporter"]
+
+_PROMETHEUS_PREFIX_RE = re.compile(r"^[A-Za-z_:][A-Za-z0-9_:]*$")
 
 
 class MetricsExporter:
     """Format UPDE state, regime, and latency as Prometheus text exposition."""
 
     def __init__(self, prefix: str = "spo") -> None:
+        if not isinstance(prefix, str) or not _PROMETHEUS_PREFIX_RE.fullmatch(prefix):
+            raise ValueError(
+                "prefix must be a valid Prometheus metric prefix "
+                "([A-Za-z_:][A-Za-z0-9_:]*)"
+            )
         self._prefix = prefix
 
     def exposition_lines(

--- a/src/scpn_phase_orchestrator/adapters/opentelemetry.py
+++ b/src/scpn_phase_orchestrator/adapters/opentelemetry.py
@@ -18,6 +18,7 @@ implementation that silently discards spans and metrics.
 
 from __future__ import annotations
 
+import re
 from collections.abc import Generator
 from contextlib import contextmanager
 from typing import Any
@@ -25,6 +26,8 @@ from typing import Any
 from scpn_phase_orchestrator.upde.metrics import UPDEState
 
 __all__ = ["OTelExporter"]
+
+_SERVICE_NAME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_.-]{0,127}$")
 
 try:
     import opentelemetry.metrics as otel_metrics  # pragma: no cover
@@ -61,6 +64,13 @@ class OTelExporter:
     """
 
     def __init__(self, service_name: str = "spo") -> None:
+        if not isinstance(service_name, str) or not _SERVICE_NAME_RE.fullmatch(
+            service_name
+        ):
+            raise ValueError(
+                "service_name must start with a letter and contain only "
+                "letters, digits, underscore, dot, or hyphen"
+            )
         self._service_name = service_name
         self._enabled = _HAS_OTEL
         self._tracer: Any = None

--- a/tests/test_metrics_exporter.py
+++ b/tests/test_metrics_exporter.py
@@ -9,6 +9,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 
 from scpn_phase_orchestrator.adapters.metrics_exporter import MetricsExporter
 from scpn_phase_orchestrator.upde.metrics import LayerState, UPDEState
@@ -75,6 +76,18 @@ def test_custom_prefix():
     result = exp.export(state, "nominal", 1.0)
     assert "myapp_r_global" in result
     assert "spo_r_global" not in result
+
+
+@pytest.mark.parametrize("prefix", ["", "1spo", "bad-name", "bad name"])
+def test_invalid_prefix_rejected(prefix: str):
+    with pytest.raises(ValueError, match="prefix"):
+        MetricsExporter(prefix=prefix)
+
+
+def test_prometheus_colon_prefix_is_valid():
+    exp = MetricsExporter(prefix="spo:internal")
+    state = _make_state([0.5])
+    assert "spo:internal_r_global" in exp.export(state, "nominal", 1.0)
 
 
 def test_export_pac_max():

--- a/tests/test_opentelemetry_adapter.py
+++ b/tests/test_opentelemetry_adapter.py
@@ -9,6 +9,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 
 from scpn_phase_orchestrator.adapters.opentelemetry import OTelExporter, _NoOpSpan
 from scpn_phase_orchestrator.upde.metrics import LayerState, LockSignature, UPDEState
@@ -89,6 +90,15 @@ class TestOTelExporter:
     def test_custom_service_name(self) -> None:
         exp = OTelExporter(service_name="custom_spo")
         assert exp._service_name == "custom_spo"
+
+    @pytest.mark.parametrize("service_name", ["", "1spo", "bad name", "bad/name"])
+    def test_invalid_service_name_rejected(self, service_name: str) -> None:
+        with pytest.raises(ValueError, match="service_name"):
+            OTelExporter(service_name=service_name)
+
+    def test_hyphenated_service_name_is_valid(self) -> None:
+        exp = OTelExporter(service_name="test-svc")
+        assert exp._service_name == "test-svc"
 
     def test_default_service_name(self) -> None:
         exp = OTelExporter()


### PR DESCRIPTION
## Summary
- validate MetricsExporter prefixes before Prometheus text exposition
- validate OTelExporter service names before tracer and meter construction
- preserve valid names such as spo, myapp, spo:internal, custom_spo, and test-svc
- add focused regression coverage for the U1 configuration-validation backlog

## Local validation
- .venv-linux/bin/ruff check src/scpn_phase_orchestrator/adapters/metrics_exporter.py src/scpn_phase_orchestrator/adapters/opentelemetry.py tests/test_metrics_exporter.py tests/test_opentelemetry_adapter.py tests/test_adapters.py
- .venv-linux/bin/ruff format --check src/scpn_phase_orchestrator/adapters/metrics_exporter.py src/scpn_phase_orchestrator/adapters/opentelemetry.py tests/test_metrics_exporter.py tests/test_opentelemetry_adapter.py tests/test_adapters.py
- .venv-linux/bin/python -m mypy src/scpn_phase_orchestrator/adapters/metrics_exporter.py src/scpn_phase_orchestrator/adapters/opentelemetry.py
- .venv-linux/bin/python -m pytest tests/test_metrics_exporter.py tests/test_opentelemetry_adapter.py tests/test_adapters.py
- .venv-linux/bin/python -m bandit -q src/scpn_phase_orchestrator/adapters/metrics_exporter.py src/scpn_phase_orchestrator/adapters/opentelemetry.py
- git diff --check
- staged diff audit clean

Full pytest/coverage gate is delegated to remote CI per the temporary local-hardware rule.