### PR TITLE
Validate domain bridge cardinalities

### DIFF
--- a/src/scpn_phase_orchestrator/adapters/fusion_core_bridge.py
+++ b/src/scpn_phase_orchestrator/adapters/fusion_core_bridge.py
@@ -8,6 +8,8 @@
 
 from __future__ import annotations
 
+from numbers import Integral
+
 import numpy as np
 from numpy.typing import NDArray
 
@@ -36,10 +38,19 @@ class FusionCoreBridge:
     All methods work without scpn-fusion-core (pure numpy + dict).
     """
 
+    _n_layers: int
+
     def __init__(self, n_layers: int = 6):
-        if n_layers < 1:
-            raise ValueError(f"n_layers must be >= 1, got {n_layers}")
-        self._n_layers = n_layers
+        if (
+            isinstance(n_layers, bool)
+            or not isinstance(n_layers, Integral)
+            or not 1 <= n_layers <= len(_OBS_NAMES)
+        ):
+            raise ValueError(
+                f"n_layers must be an integer in [1, {len(_OBS_NAMES)}], "
+                f"got {n_layers!r}"
+            )
+        self._n_layers = int(n_layers)
 
     def observables_to_phases(self, snapshot: dict) -> NDArray:
         """Map 6 fusion observables to [0, 2*pi) phases.

--- a/src/scpn_phase_orchestrator/adapters/plasma_control_bridge.py
+++ b/src/scpn_phase_orchestrator/adapters/plasma_control_bridge.py
@@ -8,6 +8,8 @@
 
 from __future__ import annotations
 
+from numbers import Integral
+
 import numpy as np
 from numpy.typing import NDArray
 
@@ -22,6 +24,13 @@ TWO_PI = 2.0 * np.pi
 Q_MIN_STABLE = 1.0  # Kruskal-Shafranov limit
 BETA_N_LIMIT = 2.8  # Troyon no-wall limit
 GREENWALD_LIMIT = 1.2  # Greenwald density fraction
+_PLASMA_LAYER_COUNT = 8
+
+
+def _validate_positive_int(value: object, *, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, Integral) or value < 1:
+        raise ValueError(f"{name} must be a positive integer, got {value!r}")
+    return int(value)
 
 
 class PlasmaControlBridge:
@@ -30,9 +39,14 @@ class PlasmaControlBridge:
     All methods work without scpn-control installed (pure numpy + dict).
     """
 
+    _n_layers: int
+
     def __init__(self, n_layers: int = 8):
-        if n_layers < 1:
-            raise ValueError(f"n_layers must be >= 1, got {n_layers}")
+        n_layers = _validate_positive_int(n_layers, name="n_layers")
+        if n_layers > _PLASMA_LAYER_COUNT:
+            raise ValueError(
+                f"n_layers must be <= {_PLASMA_LAYER_COUNT}, got {n_layers!r}"
+            )
         self._n_layers = n_layers
 
     def import_knm_spec(self, knm_spec_or_dict: object) -> CouplingState:
@@ -43,7 +57,10 @@ class PlasmaControlBridge:
         """
         if isinstance(knm_spec_or_dict, dict):
             layer_knm = np.asarray(knm_spec_or_dict["matrix"], dtype=np.float64)
-            n_per = int(knm_spec_or_dict.get("n_osc_per_layer", 2))
+            n_per = _validate_positive_int(
+                knm_spec_or_dict.get("n_osc_per_layer", 2),
+                name="n_osc_per_layer",
+            )
         else:
             layer_knm = np.asarray(knm_spec_or_dict, dtype=np.float64)
             n_per = 2
@@ -67,6 +84,10 @@ class PlasmaControlBridge:
 
         Returns frequencies ordered: micro_turbulence(fast) → plasma_wall(slow).
         """
+        n_osc_per_layer = _validate_positive_int(
+            n_osc_per_layer,
+            name="n_osc_per_layer",
+        )
         # 8 characteristic plasma timescales (normalised, rad/s)
         layer_omegas = np.array(
             [

--- a/tests/test_fusion_core_bridge.py
+++ b/tests/test_fusion_core_bridge.py
@@ -80,9 +80,15 @@ class TestPhasesToFeedback:
 
 
 class TestConstructorValidation:
-    def test_n_layers_zero_raises(self):
-        with pytest.raises(ValueError, match="n_layers must be >= 1"):
-            FusionCoreBridge(n_layers=0)
+    @pytest.mark.parametrize("n_layers", [True, 1.5, "2", 0, 7])
+    def test_invalid_n_layers_raise(self, n_layers: object):
+        with pytest.raises(ValueError, match="n_layers"):
+            FusionCoreBridge(n_layers=n_layers)
+
+    def test_supported_subset_layer_count(self):
+        bridge = FusionCoreBridge(n_layers=3)
+        phases = bridge.observables_to_phases({})
+        assert phases.shape == (3,)
 
 
 class TestQProfileImport:

--- a/tests/test_plasma_control_bridge.py
+++ b/tests/test_plasma_control_bridge.py
@@ -19,9 +19,14 @@ TWO_PI = 2.0 * np.pi
 
 
 class TestConstructorValidation:
-    def test_n_layers_zero_raises(self):
-        with pytest.raises(ValueError, match="n_layers must be >= 1"):
-            PlasmaControlBridge(n_layers=0)
+    @pytest.mark.parametrize("n_layers", [True, 1.5, "2", 0, 9])
+    def test_invalid_n_layers_raise(self, n_layers: object):
+        with pytest.raises(ValueError, match="n_layers"):
+            PlasmaControlBridge(n_layers=n_layers)
+
+    def test_supported_subset_layer_count(self):
+        bridge = PlasmaControlBridge(n_layers=3)
+        assert len(bridge.import_plasma_omega()) == 3
 
 
 class TestKnmSpecImport:
@@ -55,6 +60,14 @@ class TestKnmSpecImport:
         bridge = PlasmaControlBridge(n_layers=4)
         with pytest.raises(ValueError, match="square"):
             bridge.import_knm_spec(np.zeros((3, 4)))
+
+    @pytest.mark.parametrize("n_osc_per_layer", [True, 0, -1, 1.5, "2"])
+    def test_rejects_invalid_n_osc_per_layer(self, n_osc_per_layer: object):
+        bridge = PlasmaControlBridge(n_layers=2)
+        with pytest.raises(ValueError, match="n_osc_per_layer"):
+            bridge.import_knm_spec(
+                {"matrix": np.eye(2).tolist(), "n_osc_per_layer": n_osc_per_layer}
+            )
 
 
 class TestSnapshotImport:
@@ -176,6 +189,12 @@ class TestPlasmaOmega:
         bridge = PlasmaControlBridge(n_layers=4)
         omegas = bridge.import_plasma_omega(n_osc_per_layer=1)
         assert len(omegas) == 4
+
+    @pytest.mark.parametrize("n_osc_per_layer", [True, 0, -1, 1.5, "2"])
+    def test_omega_rejects_invalid_oscillator_count(self, n_osc_per_layer: object):
+        bridge = PlasmaControlBridge(n_layers=4)
+        with pytest.raises(ValueError, match="n_osc_per_layer"):
+            bridge.import_plasma_omega(n_osc_per_layer=n_osc_per_layer)
 
 
 class TestPlasmaDomainpack:


### PR DESCRIPTION
## Summary
- validate FusionCoreBridge layer counts as non-boolean integers within the six supported fusion observables
- validate PlasmaControlBridge layer counts as non-boolean integers within the eight supported plasma timescale layers
- validate plasma n_osc_per_layer before Kronecker expansion and omega repetition
- add focused regression coverage for invalid bridge cardinalities and valid subset counts

## Local validation
- .venv-linux/bin/ruff format --check src/scpn_phase_orchestrator/adapters/fusion_core_bridge.py src/scpn_phase_orchestrator/adapters/plasma_control_bridge.py tests/test_fusion_core_bridge.py tests/test_plasma_control_bridge.py
- .venv-linux/bin/ruff check src/scpn_phase_orchestrator/adapters/fusion_core_bridge.py src/scpn_phase_orchestrator/adapters/plasma_control_bridge.py tests/test_fusion_core_bridge.py tests/test_plasma_control_bridge.py
- .venv-linux/bin/python -m mypy src/scpn_phase_orchestrator/adapters/fusion_core_bridge.py src/scpn_phase_orchestrator/adapters/plasma_control_bridge.py
- .venv-linux/bin/python -m pytest tests/test_fusion_core_bridge.py tests/test_plasma_control_bridge.py
- .venv-linux/bin/python -m bandit -q src/scpn_phase_orchestrator/adapters/fusion_core_bridge.py src/scpn_phase_orchestrator/adapters/plasma_control_bridge.py
- git diff --check
- staged diff audit clean

Full pytest/coverage gate is delegated to remote CI per the temporary local-hardware rule.