### PR TITLE
Validate stochastic noise inputs

### DIFF
--- a/src/scpn_phase_orchestrator/upde/stochastic.py
+++ b/src/scpn_phase_orchestrator/upde/stochastic.py
@@ -9,6 +9,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from math import isfinite
+from numbers import Real
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -31,6 +33,24 @@ class NoiseProfile:
     R_deterministic: float
 
 
+def _validate_finite_non_negative(value: object, *, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a finite non-negative real, got {value!r}")
+    value = float(value)
+    if not isfinite(value) or value < 0.0:
+        raise ValueError(f"{name} must be a finite non-negative real, got {value!r}")
+    return value
+
+
+def _validate_finite_positive(value: object, *, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a finite positive real, got {value!r}")
+    value = float(value)
+    if not isfinite(value) or value <= 0.0:
+        raise ValueError(f"{name} must be a finite positive real, got {value!r}")
+    return value
+
+
 class StochasticInjector:
     """Add calibrated noise to phase dynamics.
 
@@ -41,9 +61,7 @@ class StochasticInjector:
     """
 
     def __init__(self, D: float, seed: int | None = None):
-        if D < 0:
-            raise ValueError(f"noise strength D must be non-negative, got {D}")
-        self._D = D
+        self._D = _validate_finite_non_negative(D, name="D")
         self._rng = np.random.default_rng(seed)
 
     @property
@@ -52,12 +70,11 @@ class StochasticInjector:
 
     @D.setter
     def D(self, value: float) -> None:
-        if value < 0:
-            raise ValueError(f"D must be non-negative, got {value}")
-        self._D = value
+        self._D = _validate_finite_non_negative(value, name="D")
 
     def inject(self, phases: NDArray, dt: float) -> NDArray:
         """Add Wiener noise to phases: θ += √(2D*dt) * N(0,1)."""
+        dt = _validate_finite_positive(dt, name="dt")
         if self._D == 0.0:
             return phases
         noise = self._rng.standard_normal(len(phases))

--- a/tests/test_stochastic.py
+++ b/tests/test_stochastic.py
@@ -45,6 +45,11 @@ class TestStochasticInjector:
         with pytest.raises(ValueError, match="non-negative"):
             StochasticInjector(D=-1.0)
 
+    @pytest.mark.parametrize("D", [True, np.nan, np.inf, "1.0"])
+    def test_invalid_D_raises(self, D: object):
+        with pytest.raises(ValueError, match="D"):
+            StochasticInjector(D=D)
+
     def test_D_setter(self):
         inj = StochasticInjector(D=0.0)
         inj.D = 0.5
@@ -54,6 +59,18 @@ class TestStochasticInjector:
         inj = StochasticInjector(D=0.0)
         with pytest.raises(ValueError):
             inj.D = -1.0
+
+    @pytest.mark.parametrize("D", [False, np.nan, np.inf, "1.0"])
+    def test_D_setter_invalid_raises(self, D: object):
+        inj = StochasticInjector(D=0.0)
+        with pytest.raises(ValueError, match="D"):
+            inj.D = D
+
+    @pytest.mark.parametrize("dt", [False, 0.0, -0.01, np.nan, np.inf, "0.01"])
+    def test_invalid_dt_raises(self, dt: object):
+        inj = StochasticInjector(D=1.0)
+        with pytest.raises(ValueError, match="dt"):
+            inj.inject(np.zeros(3), dt=dt)
 
     def test_reproducible_with_seed(self):
         inj1 = StochasticInjector(D=1.0, seed=99)


### PR DESCRIPTION
## Summary
- validate StochasticInjector noise strengths as finite non-negative real values
- apply the same guard when mutating the D property
- validate positive finite timesteps before evaluating Wiener noise scale
- add regression coverage for booleans, strings, non-finite values, zero, and negative timesteps

## Local validation
- .venv-linux/bin/ruff format --check src/scpn_phase_orchestrator/upde/stochastic.py tests/test_stochastic.py
- .venv-linux/bin/ruff check src/scpn_phase_orchestrator/upde/stochastic.py tests/test_stochastic.py
- .venv-linux/bin/python -m mypy src/scpn_phase_orchestrator/upde/stochastic.py
- .venv-linux/bin/python -m pytest tests/test_stochastic.py tests/test_prop_plasticity_stochastic.py
- .venv-linux/bin/python -m bandit -q src/scpn_phase_orchestrator/upde/stochastic.py
- git diff --check
- staged diff audit clean

Full pytest/coverage gate is delegated to remote CI per the temporary local-hardware rule.