### PR TITLE
Validate delay engine config

### DIFF
--- a/src/scpn_phase_orchestrator/upde/delay.py
+++ b/src/scpn_phase_orchestrator/upde/delay.py
@@ -9,6 +9,8 @@
 from __future__ import annotations
 
 from collections import deque
+from math import isfinite
+from numbers import Integral, Real
 
 import numpy as np
 from numpy.typing import NDArray
@@ -27,6 +29,21 @@ except ImportError:
 __all__ = ["DelayBuffer", "DelayedEngine"]
 
 
+def _validate_positive_int(value: object, *, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, Integral) or value < 1:
+        raise ValueError(f"{name} must be a positive integer, got {value!r}")
+    return int(value)
+
+
+def _validate_positive_float(value: object, *, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a finite positive real, got {value!r}")
+    value = float(value)
+    if not isfinite(value) or value <= 0.0:
+        raise ValueError(f"{name} must be a finite positive real, got {value!r}")
+    return value
+
+
 class DelayBuffer:
     """Circular buffer storing phase history for delayed coupling.
 
@@ -35,13 +52,9 @@ class DelayBuffer:
     """
 
     def __init__(self, n_oscillators: int, max_delay_steps: int):
-        if n_oscillators < 1:
-            raise ValueError(f"n_oscillators must be >= 1, got {n_oscillators}")
-        if max_delay_steps < 1:
-            raise ValueError(f"max_delay_steps must be >= 1, got {max_delay_steps}")
-        self._n = n_oscillators
-        self._max = max_delay_steps
-        self._buffer: deque[NDArray] = deque(maxlen=max_delay_steps)
+        self._n = _validate_positive_int(n_oscillators, name="n_oscillators")
+        self._max = _validate_positive_int(max_delay_steps, name="max_delay_steps")
+        self._buffer: deque[NDArray] = deque(maxlen=self._max)
 
     def push(self, phases: NDArray) -> None:
         """Append a phase snapshot to the buffer."""
@@ -70,16 +83,10 @@ class DelayedEngine:
     """
 
     def __init__(self, n_oscillators: int, dt: float, delay_steps: int = 1):
-        if n_oscillators < 1:
-            raise ValueError(f"n_oscillators must be >= 1, got {n_oscillators}")
-        if dt <= 0.0:
-            raise ValueError(f"dt must be positive, got {dt}")
-        if delay_steps < 1:
-            raise ValueError(f"delay_steps must be >= 1, got {delay_steps}")
-        self._n = n_oscillators
-        self._dt = dt
-        self._delay_steps = delay_steps
-        self._buffer: deque[NDArray] = deque(maxlen=delay_steps + 1)
+        self._n = _validate_positive_int(n_oscillators, name="n_oscillators")
+        self._dt = _validate_positive_float(dt, name="dt")
+        self._delay_steps = _validate_positive_int(delay_steps, name="delay_steps")
+        self._buffer: deque[NDArray] = deque(maxlen=self._delay_steps + 1)
 
     @property
     def delay_steps(self) -> int:

--- a/tests/test_delay_config_validation.py
+++ b/tests/test_delay_config_validation.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Commercial license available
+# © Concepts 1996–2026 Miroslav Šotek. All rights reserved.
+# © Code 2020–2026 Miroslav Šotek. All rights reserved.
+# ORCID: 0009-0009-3560-0851
+# Contact: www.anulum.li | protoscience@anulum.li
+# SCPN Phase Orchestrator — delay constructor validation tests
+
+from __future__ import annotations
+
+import pytest
+
+from scpn_phase_orchestrator.upde.delay import DelayBuffer, DelayedEngine
+
+
+@pytest.mark.parametrize("n_oscillators", [False, 0, -1, 1.5, "4"])
+def test_delay_buffer_rejects_invalid_oscillator_count(n_oscillators: object) -> None:
+    with pytest.raises(ValueError, match="n_oscillators"):
+        DelayBuffer(n_oscillators=n_oscillators, max_delay_steps=3)
+
+
+@pytest.mark.parametrize("max_delay_steps", [True, 0, -1, 1.5, "3"])
+def test_delay_buffer_rejects_invalid_max_delay(max_delay_steps: object) -> None:
+    with pytest.raises(ValueError, match="max_delay_steps"):
+        DelayBuffer(n_oscillators=4, max_delay_steps=max_delay_steps)
+
+
+@pytest.mark.parametrize("n_oscillators", [True, 0, -1, 1.5, "4"])
+def test_delayed_engine_rejects_invalid_oscillator_count(n_oscillators: object) -> None:
+    with pytest.raises(ValueError, match="n_oscillators"):
+        DelayedEngine(n_oscillators=n_oscillators, dt=0.01)
+
+
+@pytest.mark.parametrize("dt", [False, 0.0, -0.01, float("nan"), float("inf"), "0.01"])
+def test_delayed_engine_rejects_invalid_dt(dt: object) -> None:
+    with pytest.raises(ValueError, match="dt"):
+        DelayedEngine(n_oscillators=4, dt=dt)
+
+
+@pytest.mark.parametrize("delay_steps", [False, 0, -1, 1.5, "3"])
+def test_delayed_engine_rejects_invalid_delay_steps(delay_steps: object) -> None:
+    with pytest.raises(ValueError, match="delay_steps"):
+        DelayedEngine(n_oscillators=4, dt=0.01, delay_steps=delay_steps)

--- a/tests/test_upde_engine_validation.py
+++ b/tests/test_upde_engine_validation.py
@@ -55,25 +55,31 @@ class TestSimplicialEngineValidation:
 
 class TestDelayBufferValidation:
     def test_rejects_zero_oscillators(self) -> None:
-        with pytest.raises(ValueError, match="n_oscillators must be >= 1"):
+        with pytest.raises(
+            ValueError, match="n_oscillators must be a positive integer"
+        ):
             DelayBuffer(n_oscillators=0, max_delay_steps=5)
 
     def test_rejects_zero_max_delay(self) -> None:
-        with pytest.raises(ValueError, match="max_delay_steps must be >= 1"):
+        with pytest.raises(
+            ValueError, match="max_delay_steps must be a positive integer"
+        ):
             DelayBuffer(n_oscillators=3, max_delay_steps=0)
 
 
 class TestDelayedEngineValidation:
     def test_rejects_zero_oscillators(self) -> None:
-        with pytest.raises(ValueError, match="n_oscillators must be >= 1"):
+        with pytest.raises(
+            ValueError, match="n_oscillators must be a positive integer"
+        ):
             DelayedEngine(n_oscillators=0, dt=0.01)
 
     def test_rejects_zero_dt(self) -> None:
-        with pytest.raises(ValueError, match="dt must be positive"):
+        with pytest.raises(ValueError, match="dt must be a finite positive real"):
             DelayedEngine(n_oscillators=4, dt=0.0)
 
     def test_rejects_zero_delay_steps(self) -> None:
-        with pytest.raises(ValueError, match="delay_steps must be >= 1"):
+        with pytest.raises(ValueError, match="delay_steps must be a positive integer"):
             DelayedEngine(n_oscillators=4, dt=0.01, delay_steps=0)
 
 


### PR DESCRIPTION
## Summary
- validate DelayBuffer oscillator and max-delay counts as positive non-boolean integers
- validate DelayedEngine oscillator and delay-step counts as positive non-boolean integers
- validate DelayedEngine dt as a finite positive real value
- add focused regression coverage for booleans, strings, non-integral counts, non-finite timesteps, zero, and negative values

## Local validation
- .venv-linux/bin/ruff format --check src/scpn_phase_orchestrator/upde/delay.py tests/test_delay_config_validation.py
- .venv-linux/bin/ruff check src/scpn_phase_orchestrator/upde/delay.py tests/test_delay_config_validation.py
- .venv-linux/bin/python -m mypy src/scpn_phase_orchestrator/upde/delay.py
- .venv-linux/bin/python -m pytest tests/test_delay_config_validation.py tests/test_delay.py tests/test_engine_rigor.py::TestDelayBuffer tests/test_engine_rigor.py::TestDelayedEngine tests/test_coverage_sprint2_4.py::TestEngineVariantsPipelineWiring::test_delayed_engine_phases_finite_and_advance
- .venv-linux/bin/python -m bandit -q src/scpn_phase_orchestrator/upde/delay.py
- git diff --check
- staged diff audit clean

Full pytest/coverage gate is delegated to remote CI per the temporary local-hardware rule.