### PR TITLE
Validate inertial engine config

### DIFF
--- a/src/scpn_phase_orchestrator/upde/inertial.py
+++ b/src/scpn_phase_orchestrator/upde/inertial.py
@@ -32,6 +32,8 @@ dispatcher selects the fastest available path.
 from __future__ import annotations
 
 from collections.abc import Callable
+from math import isfinite
+from numbers import Integral, Real
 
 import numpy as np
 from numpy.typing import NDArray
@@ -137,6 +139,21 @@ def _dispatch() -> Callable[..., tuple[NDArray, NDArray]] | None:
     return _LOADERS[ACTIVE_BACKEND]()
 
 
+def _validate_positive_int(value: object, *, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, Integral) or value < 1:
+        raise ValueError(f"{name} must be >= 1 as a non-boolean integer, got {value!r}")
+    return int(value)
+
+
+def _validate_positive_float(value: object, *, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be positive finite real, got {value!r}")
+    coerced = float(value)
+    if not isfinite(coerced) or coerced <= 0.0:
+        raise ValueError(f"{name} must be positive finite real, got {value!r}")
+    return coerced
+
+
 def _python_step(
     theta: NDArray,
     omega_dot: NDArray,
@@ -180,12 +197,8 @@ class InertialKuramotoEngine:
     """
 
     def __init__(self, n: int, dt: float = 0.01) -> None:
-        if n < 1:
-            raise ValueError(f"n must be >= 1, got {n}")
-        if dt <= 0.0:
-            raise ValueError(f"dt must be positive, got {dt}")
-        self._n = n
-        self._dt = dt
+        self._n = _validate_positive_int(n, name="n")
+        self._dt = _validate_positive_float(dt, name="dt")
 
     def step(
         self,

--- a/tests/test_inertial_config_validation.py
+++ b/tests/test_inertial_config_validation.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Commercial license available
+# © Concepts 1996–2026 Miroslav Šotek. All rights reserved.
+# © Code 2020–2026 Miroslav Šotek. All rights reserved.
+# ORCID: 0009-0009-3560-0851
+# Contact: www.anulum.li | protoscience@anulum.li
+# SCPN Phase Orchestrator — inertial engine config validation tests
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from scpn_phase_orchestrator.upde.inertial import InertialKuramotoEngine
+
+
+@pytest.mark.parametrize("n", [False, 0, -1, 1.5, "4"])
+def test_inertial_engine_rejects_invalid_oscillator_count(n: Any) -> None:
+    with pytest.raises(ValueError, match="n must be >= 1"):
+        InertialKuramotoEngine(n=n)
+
+
+@pytest.mark.parametrize("dt", [False, 0.0, -0.01, float("nan"), float("inf"), "0.01"])
+def test_inertial_engine_rejects_invalid_timestep(dt: Any) -> None:
+    with pytest.raises(ValueError, match="dt must be positive"):
+        InertialKuramotoEngine(n=4, dt=dt)
+
+
+def test_inertial_engine_normalises_accepted_numpy_scalars() -> None:
+    engine = InertialKuramotoEngine(n=np.int64(4), dt=np.float64(0.01))
+
+    assert engine._n == 4
+    assert engine._dt == pytest.approx(0.01)


### PR DESCRIPTION
## Summary
- validate inertial oscillator count as a positive non-boolean integer
- validate timestep as a finite positive real
- add regression coverage for booleans, strings, non-integral counts, zero and negative values, and non-finite timesteps

## Local validation
- .venv-linux/bin/ruff format --check src/scpn_phase_orchestrator/upde/inertial.py tests/test_inertial_config_validation.py
- .venv-linux/bin/ruff check src/scpn_phase_orchestrator/upde/inertial.py tests/test_inertial_config_validation.py
- .venv-linux/bin/python -m mypy src/scpn_phase_orchestrator/upde/inertial.py
- .venv-linux/bin/python -m pytest tests/test_inertial_config_validation.py tests/test_inertial_algorithm.py tests/test_upde_engine_validation.py
- .venv-linux/bin/python -m bandit -q src/scpn_phase_orchestrator/upde/inertial.py
- git diff --check
- freeze and prohibited public-term scans clean

Full pytest/coverage remains delegated to remote CI under the approved hardware rule.