### PR TITLE
Validate OA reduction config

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -85,11 +85,17 @@
 
 - Ship 5-6 end-to-end tutorial notebooks that start from raw sources and finish with run, visualisation, and deterministic replay:
   CSV sensor stream -> P channel, event log -> I channel, state-machine trace -> S channel, binding spec, engine run, supervisor decisions, actuation output, and `audit.jsonl` replay.
+- Add a "minimal viable domainpack in 5 minutes" guide using bundled real sample data, from raw CSV/event/state inputs through scaffold, binding spec, run, visualisation, and replay.
+- Add a high-level "why this knob does what" explainer for K, alpha, zeta, Psi, damping, delay, coupling priors, supervisor thresholds, and actuation limits, aimed at users who do not already know Kuramoto control theory.
+- Publish short video walkthroughs for first run, binding-spec authoring, policy debugging, audit replay, and deployment profiles.
 - Add a visual binding-spec editor as an optional development extra. First acceptable version: load/save `binding_spec.yaml`, validate schema, expose P/I/S channel mappings, preview extractor outputs, and produce a minimal reproducible domainpack.
+- Add an interactive supervisor-policy editor and validation loop for the DSL: structured rule builder, trigger/action autocomplete, cooldown/rate-limit previews, schema diagnostics, dry-run evaluation against `audit.jsonl`, and warnings for unreachable or overlapping rules.
 - Reduce hidden YAML behaviour by documenting every inferred default in generated docs and surfacing resolved runtime configuration in CLI output and audit metadata.
 - Make the mkdocs site the primary entry point: one-page "how the pipeline fires" diagram mapping YAML -> extractors -> engines -> supervisor -> actuation, plus autodoc coverage for every public module.
 - Publish head-to-head benchmark pages for domainpacks against domain-specific baselines where appropriate, starting with power-grid swing-equation solvers and cardiac rhythm references.
 - Add reproducible build locks for application and development environments. Evaluate `uv` and `pip-tools`; keep whichever produces maintainable, hash-pinned locks across Linux, macOS, Windows, and CI.
+- Reduce setup friction with documented install profiles: Python-only, Rust FFI, JAX, Docker, and experimental auxiliary backends. Each profile needs a preflight command that reports missing toolchains, optional dependency status, and expected fallback behaviour.
+- Harden Docker deployment with a documented multi-stage image, explicit production defaults, and CI security scans using Trivy or Grype.
 - Keep adapters thin and fuzzed: `hardware_io`, Modbus, OPC-UA, ROS2, Kafka, and related network/file adapters need schema fuzzing, path-scrub tests, and production-default auth/rate-limit examples.
 - Close remaining `nn/` validation xfails/skips before v1.0 unless each has an issue reference, owner, and release-blocking decision.
 
@@ -101,6 +107,7 @@
 - Treat Rust and JAX as primary execution paths. Keep Julia, Go, Mojo, and other auxiliary backends experimental unless a maintained production workload shows a 5-10x gain or a capability Rust/JAX cannot provide.
 - Document the backend fallback chain in one place, including feature flags, runtime detection, numerical tolerance, benchmark evidence, and deprecation criteria.
 - Add a multi-language backend review gate before each minor release: keep, demote to experimental, or remove based on maintenance cost, CI burden, and measured value.
+- Extend visualisation beyond static matplotlib and the current WASM surface: Plotly/Dash dashboards for production operators, real-time streaming plots, and optional 3D views for swarm, traffic, robotics, and spatial domainpacks.
 
 ### v1.x differentiators
 

--- a/src/scpn_phase_orchestrator/upde/reduction.py
+++ b/src/scpn_phase_orchestrator/upde/reduction.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from numbers import Real
 
 import numpy as np
 from numpy.typing import NDArray
@@ -161,6 +162,15 @@ def _dispatch() -> Callable[..., tuple[float, float, float, float]] | None:
     return _LOADERS[ACTIVE_BACKEND]()
 
 
+def _validate_finite_real(value: object, *, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a finite real, got {value!r}")
+    coerced = float(value)
+    if not np.isfinite(coerced):
+        raise ValueError(f"{name} must be a finite real, got {value!r}")
+    return coerced
+
+
 def _oa_deriv(
     re: float,
     im: float,
@@ -242,8 +252,10 @@ class OttAntonsenReduction:
         K: float,
         dt: float = 0.01,
     ):
-        if not all(np.isfinite(v) for v in (omega_0, delta, K, dt)):
-            raise ValueError("omega_0, delta, K, and dt must be finite")
+        omega_0 = _validate_finite_real(omega_0, name="omega_0")
+        delta = _validate_finite_real(delta, name="delta")
+        K = _validate_finite_real(K, name="K")
+        dt = _validate_finite_real(dt, name="dt")
         if delta < 0:
             raise ValueError(f"delta (half-width) must be non-negative, got {delta}")
         if dt <= 0.0:

--- a/tests/test_reduction_config_validation.py
+++ b/tests/test_reduction_config_validation.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Commercial license available
+# © Concepts 1996–2026 Miroslav Šotek. All rights reserved.
+# © Code 2020–2026 Miroslav Šotek. All rights reserved.
+# ORCID: 0009-0009-3560-0851
+# Contact: www.anulum.li | protoscience@anulum.li
+# SCPN Phase Orchestrator — OA reduction config validation tests
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from scpn_phase_orchestrator.upde.reduction import OttAntonsenReduction
+
+
+@pytest.mark.parametrize("field", ["omega_0", "delta", "K", "dt"])
+@pytest.mark.parametrize("value", [False, "0.1", object()])
+def test_oa_reduction_rejects_non_real_constructor_scalars(
+    field: str,
+    value: Any,
+) -> None:
+    params: dict[str, Any] = {
+        "omega_0": 0.0,
+        "delta": 0.1,
+        "K": 1.0,
+        "dt": 0.01,
+    }
+    params[field] = value
+
+    with pytest.raises(ValueError, match=f"{field} must be a finite real"):
+        OttAntonsenReduction(**params)
+
+
+@pytest.mark.parametrize("field", ["omega_0", "delta", "K", "dt"])
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_oa_reduction_rejects_non_finite_constructor_scalars(
+    field: str,
+    value: float,
+) -> None:
+    params = {
+        "omega_0": 0.0,
+        "delta": 0.1,
+        "K": 1.0,
+        "dt": 0.01,
+    }
+    params[field] = value
+
+    with pytest.raises(ValueError, match=f"{field} must be a finite real"):
+        OttAntonsenReduction(**params)
+
+
+def test_oa_reduction_normalises_accepted_numpy_scalars() -> None:
+    reducer = OttAntonsenReduction(
+        omega_0=np.float64(0.2),
+        delta=np.float64(0.1),
+        K=np.float64(1.0),
+        dt=np.float64(0.01),
+    )
+
+    assert pytest.approx(0.2) == reducer._omega_0
+    assert pytest.approx(0.1) == reducer._delta
+    assert pytest.approx(1.0) == reducer._K
+    assert pytest.approx(0.01) == reducer._dt


### PR DESCRIPTION
## Summary
- validate Ott-Antonsen constructor scalars as non-boolean finite reals
- normalise accepted scalar inputs before reduction state is stored and dispatched to backends
- add regression coverage for booleans, non-real values, non-finite values, and NumPy scalar inputs
- record onboarding, policy usability, deployment friction, and richer visualisation work in ROADMAP.md

## Local validation
- .venv-linux/bin/ruff format --check src/scpn_phase_orchestrator/upde/reduction.py tests/test_reduction_config_validation.py
- .venv-linux/bin/ruff check src/scpn_phase_orchestrator/upde/reduction.py tests/test_reduction_config_validation.py
- .venv-linux/bin/python -m mypy src/scpn_phase_orchestrator/upde/reduction.py
- .venv-linux/bin/python -m pytest tests/test_reduction_config_validation.py tests/test_reduction_algorithm.py tests/test_upde_engine_validation.py
- .venv-linux/bin/python -m bandit -q src/scpn_phase_orchestrator/upde/reduction.py
- git diff --check / staged diff audits
- freeze and prohibited public-term scans clean

Full pytest/coverage remains delegated to remote CI under the approved hardware rule.