### PR TITLE
Validate splitting engine config

### DIFF
--- a/src/scpn_phase_orchestrator/upde/splitting.py
+++ b/src/scpn_phase_orchestrator/upde/splitting.py
@@ -42,6 +42,7 @@ bit-for-bit. Nonzero alpha falls back to the direct
 from __future__ import annotations
 
 from collections.abc import Callable
+from numbers import Integral, Real
 from typing import cast
 
 import numpy as np
@@ -155,6 +156,21 @@ def _dispatch() -> Callable[..., NDArray] | None:
     return _LOADERS[ACTIVE_BACKEND]()
 
 
+def _validate_positive_int(value: object, *, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, Integral) or value < 1:
+        raise ValueError(f"{name} must be >= 1 as a non-boolean integer, got {value!r}")
+    return int(value)
+
+
+def _validate_nonzero_finite_float(value: object, *, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a finite non-zero real, got {value!r}")
+    coerced = float(value)
+    if not np.isfinite(coerced) or coerced == 0.0:
+        raise ValueError(f"{name} must be a finite non-zero real, got {value!r}")
+    return coerced
+
+
 def _coupling_deriv(
     theta: NDArray,
     knm: NDArray,
@@ -254,10 +270,11 @@ class SplittingEngine:
     """
 
     def __init__(self, n_oscillators: int, dt: float):
-        if n_oscillators < 1:
-            raise ValueError(f"n_oscillators must be >= 1, got {n_oscillators}")
-        if dt == 0.0:
-            raise ValueError(f"dt must be non-zero, got {dt}")
+        n_oscillators = _validate_positive_int(
+            n_oscillators,
+            name="n_oscillators",
+        )
+        dt = _validate_nonzero_finite_float(dt, name="dt")
         # Negative dt is intentional for symplectic-reversibility
         # checks — Strang is time-reversible, so stepping forward
         # then with dt → −dt returns to the starting state.

--- a/tests/test_splitting_config_validation.py
+++ b/tests/test_splitting_config_validation.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Commercial license available
+# © Concepts 1996–2026 Miroslav Šotek. All rights reserved.
+# © Code 2020–2026 Miroslav Šotek. All rights reserved.
+# ORCID: 0009-0009-3560-0851
+# Contact: www.anulum.li | protoscience@anulum.li
+# SCPN Phase Orchestrator — splitting engine config validation tests
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from scpn_phase_orchestrator.upde.splitting import SplittingEngine
+
+
+@pytest.mark.parametrize("n_oscillators", [False, 0, -1, 1.5, "4"])
+def test_splitting_engine_rejects_invalid_oscillator_count(
+    n_oscillators: Any,
+) -> None:
+    with pytest.raises(ValueError, match="n_oscillators must be >= 1"):
+        SplittingEngine(n_oscillators=n_oscillators, dt=0.01)
+
+
+@pytest.mark.parametrize("dt", [False, 0.0, float("nan"), float("inf"), "0.01"])
+def test_splitting_engine_rejects_invalid_timestep(dt: Any) -> None:
+    with pytest.raises(ValueError, match="dt must be a finite non-zero real"):
+        SplittingEngine(n_oscillators=4, dt=dt)
+
+
+def test_splitting_engine_preserves_negative_timestep_support() -> None:
+    engine = SplittingEngine(n_oscillators=4, dt=np.float64(-0.01))
+
+    assert engine._n == 4
+    assert pytest.approx(-0.01) == engine._dt
+
+
+def test_splitting_engine_normalises_accepted_numpy_scalars() -> None:
+    engine = SplittingEngine(n_oscillators=np.int64(4), dt=np.float64(0.01))
+
+    assert engine._n == 4
+    assert pytest.approx(0.01) == engine._dt


### PR DESCRIPTION
## Summary
- validate SplittingEngine oscillator count as a positive non-boolean integer
- validate timestep as a finite non-zero real
- preserve finite negative timestep support for Strang reversibility checks
- add regression coverage for booleans, strings, non-integral counts, zero values, non-finite timesteps, and NumPy scalar inputs

## Local validation
- .venv-linux/bin/ruff format --check src/scpn_phase_orchestrator/upde/splitting.py tests/test_splitting_config_validation.py
- .venv-linux/bin/ruff check src/scpn_phase_orchestrator/upde/splitting.py tests/test_splitting_config_validation.py
- .venv-linux/bin/python -m mypy src/scpn_phase_orchestrator/upde/splitting.py
- .venv-linux/bin/python -m pytest tests/test_splitting_config_validation.py tests/test_splitting_algorithm.py tests/test_splitting.py tests/test_splitting_stability.py
- .venv-linux/bin/python -m bandit -q src/scpn_phase_orchestrator/upde/splitting.py
- git diff --check / staged diff audit
- freeze and prohibited public-term scans clean

Full pytest/coverage remains delegated to remote CI under the approved hardware rule.