### PR TITLE
Validate sparse engine config

### DIFF
--- a/src/scpn_phase_orchestrator/upde/sparse_engine.py
+++ b/src/scpn_phase_orchestrator/upde/sparse_engine.py
@@ -8,6 +8,8 @@
 
 from __future__ import annotations
 
+from numbers import Integral, Real
+
 import numpy as np
 from numpy.typing import NDArray
 
@@ -15,6 +17,21 @@ from scpn_phase_orchestrator._compat import HAS_RUST as _HAS_RUST
 from scpn_phase_orchestrator._compat import TWO_PI
 
 __all__ = ["SparseUPDEEngine"]
+
+
+def _validate_positive_int(value: object, *, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, Integral) or value < 1:
+        raise ValueError(f"{name} must be >= 1 as a non-boolean integer, got {value!r}")
+    return int(value)
+
+
+def _validate_positive_float(value: object, *, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a finite positive real, got {value!r}")
+    coerced = float(value)
+    if not np.isfinite(coerced) or coerced <= 0.0:
+        raise ValueError(f"{name} must be a finite positive real, got {value!r}")
+    return coerced
 
 
 class SparseUPDEEngine:
@@ -53,6 +70,13 @@ class SparseUPDEEngine:
             atol: Absolute tolerance for adaptive RK45.
             rtol: Relative tolerance for adaptive RK45.
         """
+        n_oscillators = _validate_positive_int(
+            n_oscillators,
+            name="n_oscillators",
+        )
+        dt = _validate_positive_float(dt, name="dt")
+        atol = _validate_positive_float(atol, name="atol")
+        rtol = _validate_positive_float(rtol, name="rtol")
         self._n = n_oscillators
         self._dt = dt
         if method not in ("euler", "rk4", "rk45"):

--- a/tests/test_sparse_engine_config_validation.py
+++ b/tests/test_sparse_engine_config_validation.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Commercial license available
+# © Concepts 1996–2026 Miroslav Šotek. All rights reserved.
+# © Code 2020–2026 Miroslav Šotek. All rights reserved.
+# ORCID: 0009-0009-3560-0851
+# Contact: www.anulum.li | protoscience@anulum.li
+# SCPN Phase Orchestrator — sparse engine config validation tests
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from scpn_phase_orchestrator.upde.sparse_engine import SparseUPDEEngine
+
+
+@pytest.mark.parametrize("n_oscillators", [False, 0, -1, 1.5, "4"])
+def test_sparse_engine_rejects_invalid_oscillator_count(
+    n_oscillators: Any,
+) -> None:
+    with pytest.raises(ValueError, match="n_oscillators must be >= 1"):
+        SparseUPDEEngine(n_oscillators=n_oscillators, dt=0.01)
+
+
+@pytest.mark.parametrize("dt", [False, 0.0, -0.01, float("nan"), float("inf"), "0.01"])
+def test_sparse_engine_rejects_invalid_timestep(dt: Any) -> None:
+    with pytest.raises(ValueError, match="dt must be a finite positive real"):
+        SparseUPDEEngine(n_oscillators=4, dt=dt)
+
+
+@pytest.mark.parametrize("field", ["atol", "rtol"])
+@pytest.mark.parametrize(
+    "value", [False, 0.0, -1e-6, float("nan"), float("inf"), "1e-6"]
+)
+def test_sparse_engine_rejects_invalid_tolerances(
+    field: str,
+    value: Any,
+) -> None:
+    kwargs: dict[str, Any] = {"n_oscillators": 4, "dt": 0.01, field: value}
+
+    with pytest.raises(ValueError, match=f"{field} must be a finite positive real"):
+        SparseUPDEEngine(**kwargs)
+
+
+def test_sparse_engine_normalises_accepted_numpy_scalars() -> None:
+    engine = SparseUPDEEngine(
+        n_oscillators=np.int64(4),
+        dt=np.float64(0.01),
+        atol=np.float64(1e-6),
+        rtol=np.float64(1e-3),
+    )
+
+    assert engine._n == 4
+    assert pytest.approx(0.01) == engine._dt
+    assert pytest.approx(1e-6) == engine._atol
+    assert pytest.approx(1e-3) == engine._rtol


### PR DESCRIPTION
## Summary
- validate SparseUPDEEngine oscillator count as a positive non-boolean integer
- validate timestep as a finite positive real
- validate RK45 tolerances as finite positive reals
- add regression coverage for booleans, strings, non-integral counts, zero/negative values, non-finite inputs, and NumPy scalar acceptance

## Local validation
- .venv-linux/bin/ruff format --check src/scpn_phase_orchestrator/upde/sparse_engine.py tests/test_sparse_engine_config_validation.py
- .venv-linux/bin/ruff check src/scpn_phase_orchestrator/upde/sparse_engine.py tests/test_sparse_engine_config_validation.py
- .venv-linux/bin/python -m mypy src/scpn_phase_orchestrator/upde/sparse_engine.py
- .venv-linux/bin/python -m pytest tests/test_sparse_engine_config_validation.py tests/test_sparse_engine.py tests/test_property_engine.py::test_dense_sparse_euler_parity tests/test_property_engine.py::test_dense_sparse_rk4_parity
- .venv-linux/bin/python -m bandit -q src/scpn_phase_orchestrator/upde/sparse_engine.py
- git diff --check / staged diff audit
- freeze and prohibited public-term scans clean

Full pytest/coverage remains delegated to remote CI under the approved hardware rule.