### PR TITLE
Validate coherence monitor config

### DIFF
--- a/src/scpn_phase_orchestrator/monitor/coherence.py
+++ b/src/scpn_phase_orchestrator/monitor/coherence.py
@@ -8,6 +8,8 @@
 
 from __future__ import annotations
 
+from numbers import Integral
+
 import numpy as np
 
 from scpn_phase_orchestrator.upde.metrics import UPDEState
@@ -15,12 +17,23 @@ from scpn_phase_orchestrator.upde.metrics import UPDEState
 __all__ = ["CoherenceMonitor"]
 
 
+def _validate_layer_indices(values: list[int], *, name: str) -> list[int]:
+    indices: list[int] = []
+    for value in values:
+        if isinstance(value, bool) or not isinstance(value, Integral) or value < 0:
+            raise ValueError(
+                f"{name} must contain non-negative integer indices, got {value!r}"
+            )
+        indices.append(int(value))
+    return indices
+
+
 class CoherenceMonitor:
     """Track coherence partitioned into good vs bad layer subsets."""
 
     def __init__(self, good_layers: list[int], bad_layers: list[int]):
-        self._good = good_layers
-        self._bad = bad_layers
+        self._good = _validate_layer_indices(good_layers, name="good_layers")
+        self._bad = _validate_layer_indices(bad_layers, name="bad_layers")
 
     def compute_r_good(self, upde_state: UPDEState) -> float:
         """Mean order parameter R across good (synchronise) layers."""

--- a/tests/test_coherence_monitor_config_validation.py
+++ b/tests/test_coherence_monitor_config_validation.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Commercial license available
+# © Concepts 1996–2026 Miroslav Šotek. All rights reserved.
+# © Code 2020–2026 Miroslav Šotek. All rights reserved.
+# ORCID: 0009-0009-3560-0851
+# Contact: www.anulum.li | protoscience@anulum.li
+# SCPN Phase Orchestrator — coherence monitor config validation tests
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from scpn_phase_orchestrator.monitor.coherence import CoherenceMonitor
+
+
+@pytest.mark.parametrize("field", ["good_layers", "bad_layers"])
+@pytest.mark.parametrize("value", [False, -1, 1.5, "1"])
+def test_coherence_monitor_rejects_invalid_layer_indices(
+    field: str,
+    value: Any,
+) -> None:
+    kwargs: dict[str, Any] = {"good_layers": [0], "bad_layers": [1]}
+    kwargs[field] = [value]
+
+    with pytest.raises(
+        ValueError,
+        match=f"{field} must contain non-negative integer indices",
+    ):
+        CoherenceMonitor(**kwargs)
+
+
+def test_coherence_monitor_allows_empty_layer_groups() -> None:
+    monitor = CoherenceMonitor(good_layers=[], bad_layers=[])
+
+    assert monitor._good == []
+    assert monitor._bad == []
+
+
+def test_coherence_monitor_copies_layer_groups() -> None:
+    good_layers = [0]
+    bad_layers = [1]
+
+    monitor = CoherenceMonitor(good_layers=good_layers, bad_layers=bad_layers)
+    good_layers.append(2)
+    bad_layers.append(3)
+
+    assert monitor._good == [0]
+    assert monitor._bad == [1]


### PR DESCRIPTION
## Summary
- validate CoherenceMonitor good/bad layer lists as non-negative non-boolean integer indices
- copy accepted layer lists during construction so caller mutation cannot change monitor routing
- keep empty layer groups valid
- add regression coverage for invalid indices, empty groups, and defensive copying

## Local validation
- .venv-linux/bin/ruff format --check src/scpn_phase_orchestrator/monitor/coherence.py tests/test_coherence_monitor_config_validation.py
- .venv-linux/bin/ruff check src/scpn_phase_orchestrator/monitor/coherence.py tests/test_coherence_monitor_config_validation.py
- .venv-linux/bin/python -m mypy src/scpn_phase_orchestrator/monitor/coherence.py
- .venv-linux/bin/python -m pytest tests/test_coherence_monitor_config_validation.py tests/test_monitor_coherence.py tests/test_drivers_oscillators.py::TestCoherenceMonitor
- .venv-linux/bin/python -m bandit -q src/scpn_phase_orchestrator/monitor/coherence.py
- git diff --check / staged diff audit
- freeze and prohibited public-term scans clean

Full pytest/coverage remains delegated to remote CI under the approved hardware rule.