### PR TITLE
Add resolved binding inspect command

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -54,6 +54,12 @@ Validate a binding spec:
 spo validate domainpacks/minimal_domain/binding_spec.yaml
 ```
 
+Inspect resolved runtime defaults before running:
+
+```bash
+spo inspect domainpacks/minimal_domain/binding_spec.yaml
+```
+
 Run a simulation and write an audit log:
 
 ```bash

--- a/src/scpn_phase_orchestrator/binding/__init__.py
+++ b/src/scpn_phase_orchestrator/binding/__init__.py
@@ -9,6 +9,7 @@
 from __future__ import annotations
 
 from scpn_phase_orchestrator.binding.loader import BindingLoadError, load_binding_spec
+from scpn_phase_orchestrator.binding.resolved import resolve_binding_summary
 from scpn_phase_orchestrator.binding.semantic import SemanticDomainCompiler
 from scpn_phase_orchestrator.binding.types import BindingSpec
 from scpn_phase_orchestrator.binding.validator import validate_binding_spec
@@ -18,5 +19,6 @@ __all__ = [
     "BindingSpec",
     "SemanticDomainCompiler",
     "load_binding_spec",
+    "resolve_binding_summary",
     "validate_binding_spec",
 ]

--- a/src/scpn_phase_orchestrator/binding/resolved.py
+++ b/src/scpn_phase_orchestrator/binding/resolved.py
@@ -73,9 +73,9 @@ def resolve_binding_summary(
                 "oscillator_ids": list(layer.oscillator_ids),
                 "range": layer_ranges[layer.index],
                 "family": layer.family,
-                "omegas": omegas[layer_ranges[layer.index][0] : layer_ranges[
-                    layer.index
-                ][1]],
+                "omegas": omegas[
+                    layer_ranges[layer.index][0] : layer_ranges[layer.index][1]
+                ],
                 "omega_source": "explicit" if layer.omegas is not None else "default",
             }
             for layer in spec.layers
@@ -138,16 +138,10 @@ def resolve_binding_summary(
             "protocol_net": spec.protocol_net is not None,
         },
         "defaults_applied": {
-            "omegas": [
-                layer.name for layer in spec.layers if layer.omegas is None
-            ],
-            "actuator_bounds": []
-            if spec.actuators
-            else sorted(_RUNTIME_VALUE_BOUNDS),
+            "omegas": [layer.name for layer in spec.layers if layer.omegas is None],
+            "actuator_bounds": [] if spec.actuators else sorted(_RUNTIME_VALUE_BOUNDS),
             "drivers": [
-                channel
-                for channel, cfg in sorted(driver_configs.items())
-                if not cfg
+                channel for channel, cfg in sorted(driver_configs.items()) if not cfg
             ],
         },
     }

--- a/src/scpn_phase_orchestrator/binding/resolved.py
+++ b/src/scpn_phase_orchestrator/binding/resolved.py
@@ -1,0 +1,184 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Commercial license available
+# © Concepts 1996–2026 Miroslav Šotek. All rights reserved.
+# © Code 2020–2026 Miroslav Šotek. All rights reserved.
+# ORCID: 0009-0009-3560-0851
+# Contact: www.anulum.li | protoscience@anulum.li
+# SCPN Phase Orchestrator — Resolved binding summaries
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from scpn_phase_orchestrator.binding.types import BindingSpec
+
+__all__ = ["resolve_binding_summary"]
+
+_RUNTIME_RATE_LIMITS = {"K": 0.1, "zeta": 0.2, "alpha": 0.1, "Psi": 0.5}
+_RUNTIME_VALUE_BOUNDS = {
+    "K": (-0.5, 0.5),
+    "zeta": (0.0, 0.5),
+    "alpha": (-1.0, 1.0),
+}
+
+
+def resolve_binding_summary(
+    spec: BindingSpec,
+    *,
+    spec_path: str | Path | None = None,
+) -> dict[str, Any]:
+    """Return a serialisable summary of runtime-relevant binding resolution.
+
+    The summary mirrors defaults and derived values used by the CLI run path:
+    oscillator counts, layer-to-index ranges, omega defaults, control interval,
+    actuator bounds, drive defaults, optional subsystems, and validation-facing
+    metadata. It is intentionally read-only and does not construct engines or
+    adapters.
+    """
+    n_oscillators = sum(len(layer.oscillator_ids) for layer in spec.layers)
+    layer_ranges = _resolve_layer_ranges(spec)
+    omegas = spec.get_omegas()
+    actuator_bounds = _resolve_actuator_bounds(spec)
+    driver_configs = spec.drivers.all_channel_configs()
+    zeta_initial = max(
+        (float(cfg.get("zeta", 0.0)) for cfg in driver_configs.values()),
+        default=0.0,
+    )
+
+    return {
+        "source": Path(spec_path).name if spec_path is not None else None,
+        "name": spec.name,
+        "version": spec.version,
+        "safety_tier": spec.safety_tier,
+        "timing": {
+            "sample_period_s": spec.sample_period_s,
+            "control_period_s": spec.control_period_s,
+            "control_interval_steps": max(
+                1, round(spec.control_period_s / spec.sample_period_s)
+            ),
+        },
+        "counts": {
+            "layers": len(spec.layers),
+            "oscillators": n_oscillators,
+            "families": len(spec.oscillator_families),
+            "boundaries": len(spec.boundaries),
+            "actuators": len(spec.actuators),
+        },
+        "layers": [
+            {
+                "name": layer.name,
+                "index": layer.index,
+                "oscillator_count": len(layer.oscillator_ids),
+                "oscillator_ids": list(layer.oscillator_ids),
+                "range": layer_ranges[layer.index],
+                "family": layer.family,
+                "omegas": omegas[layer_ranges[layer.index][0] : layer_ranges[
+                    layer.index
+                ][1]],
+                "omega_source": "explicit" if layer.omegas is not None else "default",
+            }
+            for layer in spec.layers
+        ],
+        "oscillator_families": {
+            name: {
+                "channel": family.channel,
+                "extractor_type": family.extractor_type,
+                "config_keys": sorted(family.config),
+            }
+            for name, family in sorted(spec.oscillator_families.items())
+        },
+        "coupling": {
+            "base_strength": spec.coupling.base_strength,
+            "decay_alpha": spec.coupling.decay_alpha,
+            "template_count": len(spec.coupling.templates),
+        },
+        "drivers": {
+            "channels": sorted(driver_configs),
+            "zeta_initial": zeta_initial,
+            "psi_initial": float(spec.drivers.physical.get("psi", 0.0)),
+            "psi_driver": _resolve_psi_driver(spec),
+        },
+        "objectives": {
+            "good_layers": list(spec.objectives.good_layers),
+            "bad_layers": list(spec.objectives.bad_layers),
+            "good_weight": spec.objectives.good_weight,
+            "bad_weight": spec.objectives.bad_weight,
+        },
+        "boundaries": [
+            {
+                "name": boundary.name,
+                "variable": boundary.variable,
+                "lower": boundary.lower,
+                "upper": boundary.upper,
+                "severity": boundary.severity,
+            }
+            for boundary in spec.boundaries
+        ],
+        "actuation": {
+            "rate_limits": dict(_RUNTIME_RATE_LIMITS),
+            "value_bounds": actuator_bounds,
+            "value_bounds_source": "actuators"
+            if spec.actuators
+            else "runtime_defaults",
+            "actuators": [
+                {
+                    "name": actuator.name,
+                    "knob": actuator.knob,
+                    "scope": actuator.scope,
+                    "limits": list(actuator.limits),
+                }
+                for actuator in spec.actuators
+            ],
+        },
+        "optional": {
+            "amplitude_mode": spec.amplitude is not None,
+            "imprint_model": spec.imprint_model is not None,
+            "geometry_prior": spec.geometry_prior is not None,
+            "protocol_net": spec.protocol_net is not None,
+        },
+        "defaults_applied": {
+            "omegas": [
+                layer.name for layer in spec.layers if layer.omegas is None
+            ],
+            "actuator_bounds": []
+            if spec.actuators
+            else sorted(_RUNTIME_VALUE_BOUNDS),
+            "drivers": [
+                channel
+                for channel, cfg in sorted(driver_configs.items())
+                if not cfg
+            ],
+        },
+    }
+
+
+def _resolve_layer_ranges(spec: BindingSpec) -> dict[int, tuple[int, int]]:
+    ranges: dict[int, tuple[int, int]] = {}
+    cursor = 0
+    for layer in spec.layers:
+        next_cursor = cursor + len(layer.oscillator_ids)
+        ranges[layer.index] = (cursor, next_cursor)
+        cursor = next_cursor
+    return ranges
+
+
+def _resolve_actuator_bounds(spec: BindingSpec) -> dict[str, tuple[float, float]]:
+    value_bounds: dict[str, tuple[float, float]] = {}
+    for actuator in spec.actuators:
+        if actuator.limits and len(actuator.limits) == 2:
+            value_bounds[actuator.knob] = (
+                float(actuator.limits[0]),
+                float(actuator.limits[1]),
+            )
+    return value_bounds or dict(_RUNTIME_VALUE_BOUNDS)
+
+
+def _resolve_psi_driver(spec: BindingSpec) -> str | None:
+    if "frequency" in spec.drivers.physical:
+        return "physical.frequency"
+    if "cadence_hz" in spec.drivers.informational:
+        return "informational.cadence_hz"
+    if "sequence" in spec.drivers.symbolic:
+        return "symbolic.sequence"
+    return None

--- a/src/scpn_phase_orchestrator/cli.py
+++ b/src/scpn_phase_orchestrator/cli.py
@@ -8,6 +8,7 @@
 
 from __future__ import annotations
 
+import json
 import re
 from pathlib import Path
 
@@ -17,7 +18,11 @@ import numpy as np
 from scpn_phase_orchestrator.actuation.constraints import ActionProjector
 from scpn_phase_orchestrator.audit.logger import AuditLogger
 from scpn_phase_orchestrator.audit.replay import ReplayEngine
-from scpn_phase_orchestrator.binding import load_binding_spec, validate_binding_spec
+from scpn_phase_orchestrator.binding import (
+    load_binding_spec,
+    resolve_binding_summary,
+    validate_binding_spec,
+)
 from scpn_phase_orchestrator.coupling.geometry_constraints import (
     GeometryConstraint,
     NonNegativeConstraint,
@@ -73,6 +78,83 @@ def validate(binding_spec: str) -> None:
             click.echo(f"ERROR: {e}", err=True)
         raise SystemExit(1)
     click.echo("Valid")
+
+
+@main.command("inspect")
+@click.argument("binding_spec", type=click.Path(exists=True))
+@click.option("--json-out", is_flag=True, help="Output resolved summary as JSON")
+def inspect_binding(binding_spec: str, json_out: bool) -> None:
+    """Inspect resolved runtime defaults for a binding spec."""
+    spec = load_binding_spec(Path(binding_spec))
+    errors = validate_binding_spec(spec)
+    if errors:
+        for e in errors:
+            click.echo(f"ERROR: {e}", err=True)
+        raise SystemExit(1)
+
+    try:
+        summary = resolve_binding_summary(spec, spec_path=binding_spec)
+    except ValueError as exc:
+        click.echo(f"ERROR: {exc}", err=True)
+        raise SystemExit(1) from exc
+
+    if json_out:
+        click.echo(json.dumps(summary, indent=2, sort_keys=True))
+        return
+
+    click.echo(f"Domain: {summary['name']} ({summary['version']})")
+    click.echo(f"Safety tier: {summary['safety_tier']}")
+    timing = summary["timing"]
+    click.echo(
+        "Timing: "
+        f"dt={timing['sample_period_s']}s  "
+        f"control={timing['control_period_s']}s  "
+        f"interval={timing['control_interval_steps']} steps"
+    )
+    counts = summary["counts"]
+    click.echo(
+        "Counts: "
+        f"layers={counts['layers']}  "
+        f"oscillators={counts['oscillators']}  "
+        f"families={counts['families']}  "
+        f"boundaries={counts['boundaries']}  "
+        f"actuators={counts['actuators']}"
+    )
+
+    click.echo("Layers:")
+    for layer in summary["layers"]:
+        start, stop = layer["range"]
+        click.echo(
+            f"  L{layer['index']} {layer['name']}: "
+            f"{layer['oscillator_count']} oscillators [{start}:{stop}], "
+            f"omega={layer['omega_source']}"
+        )
+
+    click.echo("Families:")
+    for name, family in summary["oscillator_families"].items():
+        click.echo(
+            f"  {name}: channel={family['channel']} "
+            f"extractor={family['extractor_type']}"
+        )
+
+    drivers = summary["drivers"]
+    click.echo(
+        "Drivers: "
+        f"zeta_initial={drivers['zeta_initial']}  "
+        f"psi_initial={drivers['psi_initial']}  "
+        f"psi_driver={drivers['psi_driver'] or 'none'}"
+    )
+    actuation = summary["actuation"]
+    click.echo(f"Actuation bounds source: {actuation['value_bounds_source']}")
+    defaults = summary["defaults_applied"]
+    if defaults["omegas"] or defaults["actuator_bounds"] or defaults["drivers"]:
+        click.echo("Defaults applied:")
+        if defaults["omegas"]:
+            click.echo(f"  omegas: {', '.join(defaults['omegas'])}")
+        if defaults["actuator_bounds"]:
+            click.echo(f"  actuator_bounds: {', '.join(defaults['actuator_bounds'])}")
+        if defaults["drivers"]:
+            click.echo(f"  empty_drivers: {', '.join(defaults['drivers'])}")
 
 
 @main.command()

--- a/tests/test_binding_resolved.py
+++ b/tests/test_binding_resolved.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Commercial license available
+# © Concepts 1996–2026 Miroslav Šotek. All rights reserved.
+# © Code 2020–2026 Miroslav Šotek. All rights reserved.
+# ORCID: 0009-0009-3560-0851
+# Contact: www.anulum.li | protoscience@anulum.li
+# SCPN Phase Orchestrator — Resolved binding summary tests
+
+from __future__ import annotations
+
+from scpn_phase_orchestrator.binding.resolved import resolve_binding_summary
+from scpn_phase_orchestrator.binding.types import (
+    ActuatorMapping,
+    BindingSpec,
+    BoundaryDef,
+    CouplingSpec,
+    DriverSpec,
+    HierarchyLayer,
+    ObjectivePartition,
+    OscillatorFamily,
+)
+
+
+def _spec() -> BindingSpec:
+    return BindingSpec(
+        name="resolved-test",
+        version="1.0.0",
+        safety_tier="research",
+        sample_period_s=0.02,
+        control_period_s=0.1,
+        layers=[
+            HierarchyLayer("sensor", 0, ["p0", "p1"], omegas=[1.2, 1.4]),
+            HierarchyLayer("controller", 1, ["s0"]),
+        ],
+        oscillator_families={
+            "physical": OscillatorFamily("P", "hilbert", {"units": "bar"}),
+            "symbolic": OscillatorFamily("S", "ring", {"states": ["a", "b"]}),
+        },
+        coupling=CouplingSpec(0.35, 0.2, {"near": "local"}),
+        drivers=DriverSpec(
+            physical={"psi": 0.3},
+            informational={"zeta": 0.05},
+            symbolic={},
+        ),
+        objectives=ObjectivePartition([0], [1], good_weight=2.0, bad_weight=0.5),
+        boundaries=[BoundaryDef("floor", "R", 0.2, None, "soft")],
+        actuators=[ActuatorMapping("global-k", "K", "global", (0.0, 3.0))],
+    )
+
+
+def test_resolve_binding_summary_counts_ranges_and_defaults() -> None:
+    summary = resolve_binding_summary(_spec(), spec_path="/private/domain.yaml")
+
+    assert summary["source"] == "domain.yaml"
+    assert summary["counts"]["oscillators"] == 3
+    assert summary["timing"]["control_interval_steps"] == 5
+    assert summary["layers"][0]["range"] == (0, 2)
+    assert summary["layers"][1]["range"] == (2, 3)
+    assert summary["layers"][0]["omega_source"] == "explicit"
+    assert summary["layers"][1]["omega_source"] == "default"
+    assert summary["layers"][1]["omegas"] == [1.0]
+    assert summary["defaults_applied"]["omegas"] == ["controller"]
+
+
+def test_resolve_binding_summary_actuation_and_drivers() -> None:
+    summary = resolve_binding_summary(_spec())
+
+    assert summary["actuation"]["value_bounds_source"] == "actuators"
+    assert summary["actuation"]["value_bounds"] == {"K": (0.0, 3.0)}
+    assert summary["actuation"]["rate_limits"]["Psi"] == 0.5
+    assert summary["drivers"]["zeta_initial"] == 0.05
+    assert summary["drivers"]["psi_initial"] == 0.3
+    assert summary["drivers"]["psi_driver"] is None
+    assert summary["oscillator_families"]["physical"]["config_keys"] == ["units"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -101,6 +101,28 @@ def test_validate_invalid(runner, invalid_spec_path):
     assert "ERROR" in result.output
 
 
+def test_inspect_text_reports_resolved_defaults(runner, valid_spec_path):
+    result = runner.invoke(main, ["inspect", valid_spec_path])
+    assert result.exit_code == 0
+    assert "Domain: cli-test (1.0.0)" in result.output
+    assert "Timing: dt=0.01s  control=0.1s  interval=10 steps" in result.output
+    assert "Counts: layers=2  oscillators=4  families=1" in result.output
+    assert "omega=default" in result.output
+    assert "Actuation bounds source: runtime_defaults" in result.output
+
+
+def test_inspect_json_reports_resolved_summary(runner, valid_spec_path):
+    result = runner.invoke(main, ["inspect", valid_spec_path, "--json-out"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["name"] == "cli-test"
+    assert data["timing"]["control_interval_steps"] == 10
+    assert data["counts"]["oscillators"] == 4
+    assert data["layers"][0]["range"] == [0, 2]
+    assert data["defaults_applied"]["omegas"] == ["L1", "L2"]
+    assert data["actuation"]["value_bounds_source"] == "runtime_defaults"
+
+
 def test_run_simulation(runner, valid_spec_path):
     result = runner.invoke(main, ["run", valid_spec_path, "--steps", "10"])
     assert result.exit_code == 0


### PR DESCRIPTION
## Summary
- Add a resolved binding summary helper for runtime-relevant binding defaults and derived values.
- Add spo inspect text and JSON output for timing, oscillator ranges, omega defaults, driver defaults, actuator bounds, optional subsystems, and counts.
- Document the command in Quickstart and cover resolver, CLI text, and CLI JSON paths with tests.

## Validation
- .venv-linux/bin/python -m pytest tests/test_cli.py tests/test_binding_resolved.py
- .venv-linux/bin/python -m ruff check touched Python files
- .venv-linux/bin/python -m mypy cli/resolved/tests slice
- .venv-linux/bin/python -m bandit -q touched source files
- .venv-linux/bin/python -m mkdocs build --strict
- git diff --cached --check
- freeze and public prohibited-term scans clean

## Stacking
Base branch is feature/spo-mkdocs-strict-autorefs so strict docs validation includes the autorefs fixes before this command lands.