### PR TITLE
Add N-channel binding algebra and Rust policy state metrics

### DIFF
--- a/domainpacks/agent_coordination/binding_spec.yaml
+++ b/domainpacks/agent_coordination/binding_spec.yaml
@@ -33,6 +33,16 @@ layers:
     oscillator_ids: [agent_a_topic, agent_b_topic, agent_c_topic, human_topic]
     omegas: [0.005, 0.005, 0.005, 0.005]
     family: topic_alignment
+  - name: operator_intent
+    index: 3
+    oscillator_ids: [human_goal, human_priority]
+    omegas: [0.004, 0.004]
+    family: operator_intent
+  - name: conflict_risk
+    index: 4
+    oscillator_ids: [merge_risk, ownership_risk]
+    omegas: [0.003, 0.003]
+    family: conflict_risk
 
 oscillator_families:
   agent_liveness:
@@ -48,6 +58,62 @@ oscillator_families:
     extractor_type: ring
     config:
       n_states: 4
+  operator_intent:
+    channel: H
+    extractor_type: event
+    config: {}
+  conflict_risk:
+    channel: Risk
+    extractor_type: graph
+    config: {}
+
+channels:
+  P:
+    role: agent_liveness
+    units: heartbeat_phase
+    metric_semantics: availability coherence
+  I:
+    role: task_cadence
+    units: task_event_phase
+    metric_semantics: task-flow regularity
+  S:
+    role: topic_state
+    units: discrete_topic_phase
+    metric_semantics: semantic topic alignment
+  H:
+    role: operator_intent
+    required: false
+    replay_semantics: event
+    metric_semantics: human priority cadence
+  Risk:
+    role: derived_conflict_risk
+    required: false
+    replay_semantics: derived
+    derived_from: [I, S, H]
+    derive_rule: merge_conflict_risk = lag(I,S) + intent_mismatch(H,S)
+    metric_semantics: derived merge-conflict phase
+
+channel_groups:
+  coordination_surface:
+    channels: [P, I, S, H, Risk]
+    required: true
+    description: channels exposed to coordination policy checks
+  derived_risk_surface:
+    channels: [Risk]
+    required: false
+    description: derived conflict-risk channels
+
+cross_channel_couplings:
+  - source: H
+    target: I
+    strength: 0.25
+    mode: directed
+    template: operator_priority_to_task_flow
+  - source: Risk
+    target: S
+    strength: 0.15
+    mode: inhibitory
+    template: risk_suppresses_topic_lock
 
 coupling:
   # Agent coupling: shared files/tasks create synchronisation pressure.
@@ -63,12 +129,16 @@ drivers:
     zeta: 0.02
   symbolic:
     zeta: 0.01
+  H:
+    cadence_hz: 0.2
+    zeta: 0.02
+  Risk: {}
 
 objectives:
   # Heartbeat + task flow = healthy coordination.
   # Topic desync = agents talking past each other.
-  good_layers: [0, 1]
-  bad_layers: [2]
+  good_layers: [0, 1, 3]
+  bad_layers: [2, 4]
   good_weight: 1.0
   bad_weight: 1.5
 

--- a/domainpacks/swarm_robotics/binding_spec.yaml
+++ b/domainpacks/swarm_robotics/binding_spec.yaml
@@ -16,12 +16,23 @@ layers:
   - name: individual_heading
     index: 0
     oscillator_ids: [bot_0, bot_1, bot_2, bot_3]
+    family: heading_angle
   - name: formation_shape
     index: 1
     oscillator_ids: [form_radius, form_angle]
+    family: formation_event
   - name: flock_direction
     index: 2
     oscillator_ids: [flock_heading, flock_speed]
+    family: formation_state
+  - name: obstacle_field
+    index: 3
+    oscillator_ids: [obstacle_left, obstacle_right, obstacle_front]
+    family: obstacle_phase
+  - name: mission_intent
+    index: 4
+    oscillator_ids: [target_heading, target_spacing]
+    family: mission_phase
 
 # Vicsek et al., PRL 75(6), 1995.
 # Heading alignment via local averaging = Kuramoto on the unit circle.
@@ -40,6 +51,62 @@ oscillator_families:
     extractor_type: ring
     config:
       n_states: 4
+  obstacle_phase:
+    channel: Env
+    extractor_type: graph
+    config: {}
+  mission_phase:
+    channel: Mission
+    extractor_type: event
+    config: {}
+
+channels:
+  P:
+    role: robot_heading
+    units: rad
+    metric_semantics: individual heading phase
+  I:
+    role: formation_event
+    units: event_phase
+    metric_semantics: formation-update cadence
+  S:
+    role: formation_state
+    units: discrete_state_phase
+    metric_semantics: formation topology state
+  Env:
+    role: obstacle_field
+    required: false
+    replay_semantics: state
+    metric_semantics: obstacle proximity phase
+  Mission:
+    role: derived_mission_intent
+    required: false
+    replay_semantics: derived
+    derived_from: [P, S, Env]
+    derive_rule: target_phase = target_heading(P) + safe_spacing(S,Env)
+    metric_semantics: target intent phase
+
+channel_groups:
+  navigation_surface:
+    channels: [P, Env, Mission]
+    required: true
+    description: channels that steer heading and avoidance decisions
+  formation_surface:
+    channels: [I, S, Mission]
+    required: true
+    description: channels that constrain group formation
+
+cross_channel_couplings:
+  - source: Env
+    target: P
+    strength: 0.35
+    mode: inhibitory
+    template: obstacle_repulsion
+  - source: Mission
+    target: P
+    strength: 0.30
+    mode: directed
+    template: mission_heading_drive
 
 coupling:
   # Proximity-based communication: coupling decays with inter-robot distance.
@@ -55,11 +122,16 @@ drivers:
     zeta: 0.02
   symbolic:
     zeta: 0.02
+  Env:
+    zeta: 0.08
+  Mission:
+    cadence_hz: 0.5
+    zeta: 0.03
 
 objectives:
   # Heading alignment + flock coherence = good; formation breakup = bad.
-  good_layers: [0, 2]
-  bad_layers: [1]
+  good_layers: [0, 2, 4]
+  bad_layers: [1, 3]
   good_weight: 1.0
   bad_weight: 1.5
 

--- a/domainpacks/traffic_flow/binding_spec.yaml
+++ b/domainpacks/traffic_flow/binding_spec.yaml
@@ -16,15 +16,27 @@ layers:
   - name: intersection
     index: 0
     oscillator_ids: [signal_phase, queue_length, pedestrian]
+    family: signal_cycle
   - name: corridor
     index: 1
     oscillator_ids: [green_wave, travel_time, bus_priority]
+    family: demand_event
   - name: network
     index: 2
     oscillator_ids: [area_flow, congestion_index]
+    family: signal_state
   - name: demand
     index: 3
     oscillator_ids: [commuter, freight]
+    family: demand_event
+  - name: weather
+    index: 4
+    oscillator_ids: [rain_intensity, visibility]
+    family: weather_phase
+  - name: equity_pressure
+    index: 5
+    oscillator_ids: [pedestrian_wait, transit_delay]
+    family: equity_pressure
 
 oscillator_families:
   # Traffic signals are literal phase oscillators; Gershenson & Rosenblueth (2012)
@@ -43,6 +55,62 @@ oscillator_families:
     extractor_type: ring
     config:
       n_states: 5
+  weather_phase:
+    channel: Weather
+    extractor_type: physical
+    config: {}
+  equity_pressure:
+    channel: Equity
+    extractor_type: graph
+    config: {}
+
+channels:
+  P:
+    role: signal_cycle
+    units: rad
+    metric_semantics: signal oscillator phase
+  I:
+    role: demand_event
+    units: event_phase
+    metric_semantics: arrival-event cadence
+  S:
+    role: signal_state
+    units: discrete_signal_state
+    metric_semantics: controller state phase
+  Weather:
+    role: environmental_modifier
+    required: false
+    replay_semantics: state
+    metric_semantics: weather-induced speed phase
+  Equity:
+    role: derived_service_pressure
+    required: false
+    replay_semantics: derived
+    derived_from: [I, S, Weather]
+    derive_rule: equity_phase = wait_pressure(I,S) + weather_delay(Weather)
+    metric_semantics: service-equity pressure phase
+
+channel_groups:
+  controller_surface:
+    channels: [P, I, S]
+    required: true
+    description: channels required for signal timing
+  operations_surface:
+    channels: [Weather, Equity]
+    required: false
+    description: optional operational modifiers for resilient timing
+
+cross_channel_couplings:
+  - source: Weather
+    target: P
+    strength: 0.20
+    mode: directed
+    template: weather_speed_adjustment
+  - source: Equity
+    target: S
+    strength: 0.25
+    mode: excitatory
+    template: service_priority_lift
 
 coupling:
   # Signal coordination coupling proportional to link capacity
@@ -58,11 +126,14 @@ drivers:
     zeta: 0.02
   symbolic:
     zeta: 0.02
+  Weather:
+    zeta: 0.04
+  Equity: {}
 
 objectives:
   # Green wave sync = good; intersection queue sync = gridlock; demand surge = bad
-  good_layers: [1]
-  bad_layers: [0, 3]
+  good_layers: [1, 5]
+  bad_layers: [0, 3, 4]
   good_weight: 1.0
   bad_weight: 1.5
 

--- a/spo-kernel/crates/spo-ffi/src/lib.rs
+++ b/spo-kernel/crates/spo-ffi/src/lib.rs
@@ -1698,6 +1698,25 @@ impl PyRuleEngine {
             .collect()
     }
 
+    /// Evaluate rules against UPDE layer order parameters and partitions.
+    #[pyo3(signature = (regime, layer_rs, good_layers, bad_layers, extra = None))]
+    fn evaluate_state(
+        &mut self,
+        regime: &str,
+        layer_rs: Vec<f64>,
+        good_layers: Vec<usize>,
+        bad_layers: Vec<usize>,
+        extra: Option<HashMap<String, f64>>,
+    ) -> Vec<(String, String, f64, f64, String)> {
+        let state = make_upde_state(&layer_rs);
+        let extra = extra.unwrap_or_default();
+        self.inner
+            .evaluate_state(regime, &state, &good_layers, &bad_layers, &extra)
+            .into_iter()
+            .map(|a| (a.knob, a.scope, a.value, a.ttl_s, a.rule_name))
+            .collect()
+    }
+
     fn advance_clock(&mut self, dt: f64) {
         self.inner.advance_clock(dt);
     }

--- a/spo-kernel/crates/spo-supervisor/src/boundaries.rs
+++ b/spo-kernel/crates/spo-supervisor/src/boundaries.rs
@@ -160,7 +160,7 @@ mod tests {
         };
         let mut values = HashMap::new();
         values.insert("x".into(), -0.1);
-        let state = BoundaryObserver::observe(&[def.clone()], &values);
+        let state = BoundaryObserver::observe(std::slice::from_ref(&def), &values);
         assert_eq!(state.violations.len(), 1);
 
         values.insert("x".into(), 1.5);

--- a/spo-kernel/crates/spo-supervisor/src/policy.rs
+++ b/spo-kernel/crates/spo-supervisor/src/policy.rs
@@ -121,7 +121,7 @@ mod tests {
     fn critical_damping_and_reduce() {
         let mut sp = SupervisorPolicy::new(RegimeManager::default());
         let actions = sp.decide(&make_state(0.1), &empty_boundary());
-        assert!(actions.len() >= 1);
+        assert!(!actions.is_empty());
         assert_eq!(actions[0].knob, Knob::Zeta);
     }
 

--- a/spo-kernel/crates/spo-supervisor/src/regime.rs
+++ b/spo-kernel/crates/spo-supervisor/src/regime.rs
@@ -228,8 +228,10 @@ mod tests {
 
     #[test]
     fn recovery_from_critical_in_degraded_band() {
-        let mut rm = RegimeManager::default();
-        rm.current = Regime::Critical;
+        let rm = RegimeManager {
+            current: Regime::Critical,
+            ..Default::default()
+        };
         let regime = rm.evaluate(&make_state(0.5), &empty_boundary());
         assert_eq!(regime, Regime::Recovery);
     }
@@ -237,8 +239,10 @@ mod tests {
     #[test]
     fn critical_goes_through_recovery() {
         // Python parity: Critical never jumps directly to Nominal.
-        let mut rm = RegimeManager::default();
-        rm.current = Regime::Critical;
+        let mut rm = RegimeManager {
+            current: Regime::Critical,
+            ..Default::default()
+        };
         // R=0.8 above all thresholds — still returns Recovery (must step through)
         let regime = rm.evaluate(&make_state(0.8), &empty_boundary());
         assert_eq!(regime, Regime::Recovery);
@@ -266,8 +270,10 @@ mod tests {
 
     #[test]
     fn same_regime_no_transition() {
-        let mut rm = RegimeManager::default();
-        rm.current = Regime::Nominal;
+        let mut rm = RegimeManager {
+            current: Regime::Nominal,
+            ..Default::default()
+        };
         let result = rm.transition(Regime::Nominal);
         assert_eq!(result, Regime::Nominal);
     }
@@ -367,7 +373,7 @@ mod tests {
         let mut rm = RegimeManager::new(0.05, 0);
         rm.set_event_bus(EventBus::new(10));
         rm.force_transition(Regime::Critical);
-        let bus = rm.event_bus().unwrap();
+        let bus = rm.event_bus().expect("bus set");
         assert_eq!(bus.count(), 1);
     }
 }

--- a/spo-kernel/crates/spo-supervisor/src/rule_engine.rs
+++ b/spo-kernel/crates/spo-supervisor/src/rule_engine.rs
@@ -13,6 +13,7 @@
 use std::collections::HashMap;
 
 use crate::petri_net::GuardOp;
+use spo_types::UPDEState;
 
 /// Single condition: metric op threshold.
 #[derive(Debug, Clone)]
@@ -164,6 +165,19 @@ impl RuleEngine {
         actions
     }
 
+    /// Evaluate against a structured UPDE state plus good/bad layer partitions.
+    pub fn evaluate_state(
+        &mut self,
+        regime: &str,
+        state: &UPDEState,
+        good_layers: &[usize],
+        bad_layers: &[usize],
+        extra: &HashMap<String, f64>,
+    ) -> Vec<FiredAction> {
+        let ctx = state_context(state, good_layers, bad_layers, extra);
+        self.evaluate(regime, &ctx)
+    }
+
     pub fn reset(&mut self) {
         self.fire_counts.clear();
         self.last_fire_t.clear();
@@ -171,9 +185,45 @@ impl RuleEngine {
     }
 }
 
+/// Build the metric context used by rule evaluation from a UPDE state.
+#[must_use]
+pub fn state_context(
+    state: &UPDEState,
+    good_layers: &[usize],
+    bad_layers: &[usize],
+    extra: &HashMap<String, f64>,
+) -> HashMap<String, f64> {
+    let mut ctx = extra.clone();
+    ctx.insert("stability_proxy".into(), state.stability_proxy);
+    ctx.insert("R".into(), state.mean_r());
+
+    for (idx, layer) in state.layers.iter().enumerate() {
+        ctx.insert(format!("R.{idx}"), layer.r);
+        ctx.insert(format!("R_{idx}"), layer.r);
+        ctx.insert(format!("psi.{idx}"), layer.psi);
+        ctx.insert(format!("psi_{idx}"), layer.psi);
+    }
+
+    for (idx, &layer_idx) in good_layers.iter().enumerate() {
+        if let Some(layer) = state.layers.get(layer_idx) {
+            ctx.insert(format!("R_good.{idx}"), layer.r);
+            ctx.insert(format!("R_good_{idx}"), layer.r);
+        }
+    }
+    for (idx, &layer_idx) in bad_layers.iter().enumerate() {
+        if let Some(layer) = state.layers.get(layer_idx) {
+            ctx.insert(format!("R_bad.{idx}"), layer.r);
+            ctx.insert(format!("R_bad_{idx}"), layer.r);
+        }
+    }
+
+    ctx
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use spo_types::{LayerState, Regime, UPDEState};
 
     fn simple_rule(name: &str, regime: &str, metric: &str, op: GuardOp, thresh: f64) -> PolicyRule {
         PolicyRule {
@@ -195,6 +245,19 @@ mod tests {
         }
     }
 
+    fn state(rs: &[f64]) -> UPDEState {
+        UPDEState {
+            layers: rs
+                .iter()
+                .copied()
+                .map(|r| LayerState { r, psi: 0.0 })
+                .collect(),
+            cross_layer_alignment: vec![],
+            stability_proxy: 0.42,
+            regime: Regime::Nominal,
+        }
+    }
+
     #[test]
     fn fires_when_condition_met() {
         let mut eng = RuleEngine::new(vec![simple_rule(
@@ -208,6 +271,28 @@ mod tests {
         let actions = eng.evaluate("degraded", &ctx);
         assert_eq!(actions.len(), 1);
         assert_eq!(actions[0].rule_name, "boost");
+    }
+
+    #[test]
+    fn state_context_exposes_layer_and_partition_metrics() {
+        let ctx = state_context(&state(&[0.2, 0.8, 0.4]), &[1], &[0, 2], &HashMap::new());
+
+        assert_eq!(ctx["stability_proxy"], 0.42);
+        assert!((ctx["R"] - (0.2 + 0.8 + 0.4) / 3.0).abs() < 1e-12);
+        assert_eq!(ctx["R.1"], 0.8);
+        assert_eq!(ctx["R_good.0"], 0.8);
+        assert_eq!(ctx["R_bad.1"], 0.4);
+    }
+
+    #[test]
+    fn evaluate_state_uses_good_bad_layer_metrics() {
+        let rule = simple_rule("suppress_bad", "CRITICAL", "R_bad.0", GuardOp::Lt, 0.3);
+        let mut eng = RuleEngine::new(vec![rule]);
+        let actions =
+            eng.evaluate_state("critical", &state(&[0.2, 0.9]), &[1], &[0], &HashMap::new());
+
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0].rule_name, "suppress_bad");
     }
 
     #[test]

--- a/src/scpn_phase_orchestrator/binding/loader.py
+++ b/src/scpn_phase_orchestrator/binding/loader.py
@@ -17,7 +17,10 @@ from scpn_phase_orchestrator.binding.types import (
     AmplitudeSpec,
     BindingSpec,
     BoundaryDef,
+    ChannelGroupSpec,
+    ChannelSpec,
     CouplingSpec,
+    CrossChannelCouplingSpec,
     DriverSpec,
     GeometrySpec,
     HierarchyLayer,
@@ -93,6 +96,18 @@ def _require_number(value: object, context: str) -> float:
     return float(value)
 
 
+def _require_bool(value: object, context: str) -> bool:
+    if not isinstance(value, bool):
+        raise _expected("boolean", context, value)
+    return value
+
+
+def _optional_bool(value: object, context: str, default: bool) -> bool:
+    if value is None:
+        return default
+    return _require_bool(value, context)
+
+
 def _optional_number(value: object, context: str) -> float | None:
     if value is None:
         return None
@@ -157,6 +172,115 @@ def _load_drivers(data: dict) -> DriverSpec:
         symbolic=driver_maps.get("symbolic", {}),
         extra=extra_drivers,
     )
+
+
+def _load_channels(data: dict) -> dict[str, ChannelSpec]:
+    """Load optional typed N-channel declarations."""
+    channels_data = _optional_mapping(data.get("channels"), "channels")
+    channels: dict[str, ChannelSpec] = {}
+    for raw_name, raw_channel in channels_data.items():
+        name = _require_str(raw_name, "channels key")
+        if not is_valid_channel_id(name):
+            raise BindingLoadError(f"channels.{name}: invalid channel identifier")
+        channel_data = _require_mapping(raw_channel, f"channels.{name}")
+        channels[name] = ChannelSpec(
+            role=_require_str(
+                channel_data.get("role", "domain"), f"channels.{name}.role"
+            ),
+            required=_optional_bool(
+                channel_data.get("required"), f"channels.{name}.required", True
+            ),
+            units=_optional_str(channel_data.get("units"), f"channels.{name}.units"),
+            metric_semantics=_optional_str(
+                channel_data.get("metric_semantics"),
+                f"channels.{name}.metric_semantics",
+            ),
+            coupling_participation=_optional_bool(
+                channel_data.get("coupling_participation"),
+                f"channels.{name}.coupling_participation",
+                True,
+            ),
+            audit_serialisation=_optional_bool(
+                channel_data.get("audit_serialisation"),
+                f"channels.{name}.audit_serialisation",
+                True,
+            ),
+            replay_semantics=_require_str(
+                channel_data.get("replay_semantics", "phase"),
+                f"channels.{name}.replay_semantics",
+            ),
+            supervisor_visibility=_optional_bool(
+                channel_data.get("supervisor_visibility"),
+                f"channels.{name}.supervisor_visibility",
+                True,
+            ),
+            derived_from=_optional_str_list(
+                channel_data.get("derived_from"), f"channels.{name}.derived_from"
+            ),
+            derive_rule=_optional_str(
+                channel_data.get("derive_rule"), f"channels.{name}.derive_rule"
+            ),
+        )
+    return channels
+
+
+def _load_channel_groups(data: dict) -> dict[str, ChannelGroupSpec]:
+    """Load optional N-channel group declarations."""
+    groups_data = _optional_mapping(data.get("channel_groups"), "channel_groups")
+    groups: dict[str, ChannelGroupSpec] = {}
+    for raw_name, raw_group in groups_data.items():
+        name = _require_str(raw_name, "channel_groups key")
+        if not is_valid_channel_id(name):
+            raise BindingLoadError(
+                f"channel_groups.{name}: invalid channel group identifier"
+            )
+        group_data = _require_mapping(raw_group, f"channel_groups.{name}")
+        groups[name] = ChannelGroupSpec(
+            channels=_optional_str_list(
+                _require(group_data, "channels", f"channel_groups.{name}"),
+                f"channel_groups.{name}.channels",
+            ),
+            required=_optional_bool(
+                group_data.get("required"), f"channel_groups.{name}.required", True
+            ),
+            description=_optional_str(
+                group_data.get("description"), f"channel_groups.{name}.description"
+            ),
+        )
+    return groups
+
+
+def _load_cross_channel_couplings(data: dict) -> list[CrossChannelCouplingSpec]:
+    """Load optional cross-channel coupling declarations."""
+    couplings = []
+    for i, raw_coupling in enumerate(
+        _optional_list(data.get("cross_channel_couplings"), "cross_channel_couplings")
+    ):
+        c = _require_mapping(raw_coupling, f"cross_channel_couplings[{i}]")
+        couplings.append(
+            CrossChannelCouplingSpec(
+                source=_require_str(
+                    _require(c, "source", "cross_channel_couplings[]"),
+                    "cross_channel_couplings[].source",
+                ),
+                target=_require_str(
+                    _require(c, "target", "cross_channel_couplings[]"),
+                    "cross_channel_couplings[].target",
+                ),
+                strength=_require_number(
+                    _require(c, "strength", "cross_channel_couplings[]"),
+                    "cross_channel_couplings[].strength",
+                ),
+                mode=_require_str(
+                    c.get("mode", "bidirectional"),
+                    "cross_channel_couplings[].mode",
+                ),
+                template=_optional_str(
+                    c.get("template"), "cross_channel_couplings[].template"
+                ),
+            )
+        )
+    return couplings
 
 
 def load_binding_spec(path: str | Path) -> BindingSpec:
@@ -248,6 +372,9 @@ def load_binding_spec(path: str | Path) -> BindingSpec:
     )
 
     drivers = _load_drivers(data)
+    channels = _load_channels(data)
+    channel_groups = _load_channel_groups(data)
+    cross_channel_couplings = _load_cross_channel_couplings(data)
 
     obj = _require_mapping(_require(data, "objectives", "root"), "objectives")
     objectives = ObjectivePartition(
@@ -416,4 +543,7 @@ def load_binding_spec(path: str | Path) -> BindingSpec:
         geometry_prior=geometry,
         protocol_net=protocol_net,
         amplitude=amplitude,
+        channels=channels,
+        channel_groups=channel_groups,
+        cross_channel_couplings=cross_channel_couplings,
     )

--- a/src/scpn_phase_orchestrator/binding/resolved.py
+++ b/src/scpn_phase_orchestrator/binding/resolved.py
@@ -34,7 +34,7 @@ def resolved_binding_config(spec: BindingSpec) -> dict[str, object]:
         for name, family in sorted(spec.oscillator_families.items())
     }
     driver_configs = spec.drivers.all_channel_configs()
-    channels = sorted(set(family_channels.values()) | set(driver_configs))
+    channels = sorted(spec.used_channels())
 
     family_summaries: dict[str, dict[str, object]] = {}
     for name, family in sorted(spec.oscillator_families.items()):
@@ -77,6 +77,7 @@ def resolved_binding_config(spec: BindingSpec) -> dict[str, object]:
             }
         )
         driver_config = driver_configs.get(channel, {})
+        channel_spec = spec.channels.get(channel)
         channel_summaries[channel] = {
             "families": family_names,
             "extractors": extractors,
@@ -86,6 +87,33 @@ def resolved_binding_config(spec: BindingSpec) -> dict[str, object]:
             "oscillator_count": sum(
                 len(layer.oscillator_ids) for layer in channel_layers
             ),
+            "declared": channel_spec is not None,
+            "role": channel_spec.role if channel_spec is not None else None,
+            "required": channel_spec.required if channel_spec is not None else None,
+            "units": channel_spec.units if channel_spec is not None else None,
+            "metric_semantics": (
+                channel_spec.metric_semantics if channel_spec is not None else None
+            ),
+            "coupling_participation": (
+                channel_spec.coupling_participation
+                if channel_spec is not None
+                else None
+            ),
+            "audit_serialisation": (
+                channel_spec.audit_serialisation if channel_spec is not None else None
+            ),
+            "replay_semantics": (
+                channel_spec.replay_semantics if channel_spec is not None else None
+            ),
+            "supervisor_visibility": (
+                channel_spec.supervisor_visibility if channel_spec is not None else None
+            ),
+            "derived_from": (
+                list(channel_spec.derived_from) if channel_spec is not None else []
+            ),
+            "derive_rule": channel_spec.derive_rule
+            if channel_spec is not None
+            else None,
         }
 
     features = {
@@ -106,6 +134,24 @@ def resolved_binding_config(spec: BindingSpec) -> dict[str, object]:
         "layer_count": len(spec.layers),
         "oscillator_count": n_osc,
         "channels": channel_summaries,
+        "channel_groups": {
+            name: {
+                "channels": list(group.channels),
+                "required": group.required,
+                "description": group.description,
+            }
+            for name, group in sorted(spec.channel_groups.items())
+        },
+        "cross_channel_couplings": [
+            {
+                "source": coupling.source,
+                "target": coupling.target,
+                "strength": coupling.strength,
+                "mode": coupling.mode,
+                "template": coupling.template,
+            }
+            for coupling in spec.cross_channel_couplings
+        ],
         "families": family_summaries,
         "layers": layer_summaries,
         "unassigned_layer_count": sum(
@@ -183,6 +229,24 @@ def format_resolved_binding_config(summary: dict[str, object]) -> list[str]:
             f"layers={raw_info.get('layer_count', 0)} "
             f"oscillators={raw_info.get('oscillator_count', 0)}"
         )
+        if raw_info.get("declared"):
+            role = raw_info.get("role") or "domain"
+            replay = raw_info.get("replay_semantics") or "phase"
+            derived_from = _string_list(raw_info.get("derived_from"))
+            derived = f" derived_from={','.join(derived_from)}" if derived_from else ""
+            lines.append(
+                f"    metadata: role={role} replay={replay} "
+                f"supervisor={raw_info.get('supervisor_visibility')}{derived}"
+            )
+
+    groups = summary.get("channel_groups", {})
+    if isinstance(groups, dict) and groups:
+        group_names = ", ".join(sorted(str(name) for name in groups))
+        lines.append(f"  channel_groups: {group_names}")
+
+    couplings = summary.get("cross_channel_couplings", [])
+    if isinstance(couplings, list) and couplings:
+        lines.append(f"  cross_channel_couplings: {len(couplings)}")
 
     unassigned = summary.get("unassigned_layer_count", 0)
     if unassigned:

--- a/src/scpn_phase_orchestrator/binding/types.py
+++ b/src/scpn_phase_orchestrator/binding/types.py
@@ -9,7 +9,7 @@
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from scpn_phase_orchestrator.exceptions import ValidationError
 
@@ -18,6 +18,9 @@ __all__ = [
     "OscillatorFamily",
     "CouplingSpec",
     "DriverSpec",
+    "ChannelSpec",
+    "ChannelGroupSpec",
+    "CrossChannelCouplingSpec",
     "ObjectivePartition",
     "BoundaryDef",
     "ActuatorMapping",
@@ -99,6 +102,42 @@ class DriverSpec:
         }
         configs.update(self.extra or {})
         return configs
+
+
+@dataclass(frozen=True)
+class ChannelSpec:
+    """Typed binding channel metadata for N-channel domainpacks."""
+
+    role: str
+    required: bool = True
+    units: str | None = None
+    metric_semantics: str | None = None
+    coupling_participation: bool = True
+    audit_serialisation: bool = True
+    replay_semantics: str = "phase"
+    supervisor_visibility: bool = True
+    derived_from: list[str] = field(default_factory=list)
+    derive_rule: str | None = None
+
+
+@dataclass(frozen=True)
+class ChannelGroupSpec:
+    """Named set of channels used for validation and supervisor summaries."""
+
+    channels: list[str]
+    required: bool = True
+    description: str | None = None
+
+
+@dataclass(frozen=True)
+class CrossChannelCouplingSpec:
+    """Declared coupling relation between two binding channels."""
+
+    source: str
+    target: str
+    strength: float
+    mode: str = "bidirectional"
+    template: str | None = None
 
 
 @dataclass(frozen=True)
@@ -248,6 +287,11 @@ class BindingSpec:
     geometry_prior: GeometrySpec | None = None
     protocol_net: ProtocolNetSpec | None = None
     amplitude: AmplitudeSpec | None = None
+    channels: dict[str, ChannelSpec] = field(default_factory=dict)
+    channel_groups: dict[str, ChannelGroupSpec] = field(default_factory=dict)
+    cross_channel_couplings: list[CrossChannelCouplingSpec] = field(
+        default_factory=list
+    )
 
     def get_omegas(self) -> list[float]:
         """Collect natural frequencies from all layers.
@@ -269,3 +313,17 @@ class BindingSpec:
             else:
                 result.extend([1.0] * n)
         return result
+
+    def used_channels(self) -> set[str]:
+        """Return channels referenced by families, drivers, and algebra."""
+        used = {family.channel for family in self.oscillator_families.values()}
+        used.update(self.drivers.all_channel_configs())
+        used.update(self.channels)
+        for channel in self.channels.values():
+            used.update(channel.derived_from)
+        for group in self.channel_groups.values():
+            used.update(group.channels)
+        for coupling in self.cross_channel_couplings:
+            used.add(coupling.source)
+            used.add(coupling.target)
+        return used

--- a/src/scpn_phase_orchestrator/binding/validator.py
+++ b/src/scpn_phase_orchestrator/binding/validator.py
@@ -8,6 +8,8 @@
 
 from __future__ import annotations
 
+import math
+
 from scpn_phase_orchestrator.binding.types import (
     VALID_EXTRACTORS,
     VALID_KNOBS,
@@ -18,6 +20,11 @@ from scpn_phase_orchestrator.binding.types import (
 )
 
 __all__ = ["validate_binding_spec"]
+
+_VALID_CROSS_CHANNEL_MODES = frozenset(
+    {"bidirectional", "directed", "excitatory", "inhibitory"}
+)
+_VALID_REPLAY_SEMANTICS = frozenset({"phase", "event", "state", "derived", "external"})
 
 
 def validate_binding_spec(spec: BindingSpec) -> list[str]:
@@ -49,6 +56,77 @@ def validate_binding_spec(spec: BindingSpec) -> list[str]:
         errors.append("at least one layer is required")
 
     layer_indices = {lay.index for lay in spec.layers}
+
+    used_channels = spec.used_channels()
+    for channel_id in used_channels:
+        if not is_valid_channel_id(channel_id):
+            errors.append(
+                f"channel {channel_id!r}: must match [A-Za-z][A-Za-z0-9_-]{{0,63}}"
+            )
+
+    family_driver_channels = {
+        family.channel for family in spec.oscillator_families.values()
+    }
+    family_driver_channels.update(spec.drivers.all_channel_configs())
+    declared_or_used = family_driver_channels | set(spec.channels)
+
+    for channel_name, channel_spec in spec.channels.items():
+        if channel_spec.replay_semantics not in _VALID_REPLAY_SEMANTICS:
+            errors.append(
+                f"channel {channel_name!r}: replay_semantics must be one of "
+                f"{sorted(_VALID_REPLAY_SEMANTICS)}, "
+                f"got {channel_spec.replay_semantics!r}"
+            )
+        for source in channel_spec.derived_from:
+            if source == channel_name:
+                errors.append(
+                    f"channel {channel_name!r}: derived_from must not include itself"
+                )
+            if source not in declared_or_used:
+                errors.append(
+                    f"channel {channel_name!r}: derived_from references unknown "
+                    f"channel {source!r}"
+                )
+        if channel_spec.derived_from and not channel_spec.derive_rule:
+            errors.append(
+                f"channel {channel_name!r}: derive_rule is required when "
+                "derived_from is set"
+            )
+
+    for group_name, group in spec.channel_groups.items():
+        if not group.channels:
+            errors.append(f"channel_group {group_name!r}: channels must not be empty")
+        for channel in group.channels:
+            if channel not in declared_or_used:
+                errors.append(
+                    f"channel_group {group_name!r}: references unknown channel "
+                    f"{channel!r}"
+                )
+
+    for i, coupling in enumerate(spec.cross_channel_couplings):
+        if coupling.source not in declared_or_used:
+            errors.append(
+                f"cross_channel_couplings[{i}]: source references unknown channel "
+                f"{coupling.source!r}"
+            )
+        if coupling.target not in declared_or_used:
+            errors.append(
+                f"cross_channel_couplings[{i}]: target references unknown channel "
+                f"{coupling.target!r}"
+            )
+        if coupling.source == coupling.target:
+            errors.append(
+                f"cross_channel_couplings[{i}]: source and target must differ"
+            )
+        if not math.isfinite(coupling.strength) or coupling.strength < 0.0:
+            errors.append(
+                f"cross_channel_couplings[{i}].strength must be finite and >= 0"
+            )
+        if coupling.mode not in _VALID_CROSS_CHANNEL_MODES:
+            errors.append(
+                f"cross_channel_couplings[{i}].mode must be one of "
+                f"{sorted(_VALID_CROSS_CHANNEL_MODES)}, got {coupling.mode!r}"
+            )
 
     for family_name, fam in spec.oscillator_families.items():
         if not is_valid_channel_id(fam.channel):
@@ -116,8 +194,6 @@ def validate_binding_spec(spec: BindingSpec) -> list[str]:
             )
 
     if spec.amplitude is not None:
-        import math
-
         if not math.isfinite(spec.amplitude.mu):
             errors.append("amplitude.mu must be finite")
         if spec.amplitude.epsilon < 0.0:

--- a/tests/test_binding_loader.py
+++ b/tests/test_binding_loader.py
@@ -150,6 +150,69 @@ def test_loader_preserves_named_driver_channels(tmp_path):
     assert spec.drivers.all_channel_configs()["Q"] == {"zeta": 0.25}
 
 
+def test_loader_preserves_n_channel_algebra(tmp_path):
+    data = {
+        **_SPEC_DATA,
+        "oscillator_families": {
+            "phys": {"channel": "P", "extractor_type": "hilbert", "config": {}},
+            "operator": {"channel": "H", "extractor_type": "event", "config": {}},
+            "risk": {"channel": "Risk", "extractor_type": "graph", "config": {}},
+        },
+        "channels": {
+            "P": {
+                "role": "plant",
+                "units": "rad",
+                "metric_semantics": "physical phase",
+            },
+            "H": {
+                "role": "operator_intent",
+                "replay_semantics": "event",
+                "supervisor_visibility": True,
+            },
+            "Risk": {
+                "role": "derived_risk",
+                "required": False,
+                "replay_semantics": "derived",
+                "derived_from": ["P", "H"],
+                "derive_rule": "risk = phase_lag(P,H)",
+            },
+        },
+        "channel_groups": {
+            "control_surface": {
+                "channels": ["P", "H", "Risk"],
+                "required": True,
+                "description": "channels exposed to supervisor policy",
+            }
+        },
+        "cross_channel_couplings": [
+            {
+                "source": "H",
+                "target": "P",
+                "strength": 0.25,
+                "mode": "directed",
+                "template": "operator_to_plant",
+            }
+        ],
+        "drivers": {
+            "physical": {},
+            "informational": {},
+            "symbolic": {},
+            "H": {"cadence_hz": 1.0},
+            "Risk": {},
+        },
+    }
+    p = tmp_path / "spec.json"
+    p.write_text(json.dumps(data), encoding="utf-8")
+
+    spec = load_binding_spec(p)
+
+    assert spec.channels["H"].role == "operator_intent"
+    assert spec.channels["Risk"].derived_from == ["P", "H"]
+    assert spec.channel_groups["control_surface"].channels == ["P", "H", "Risk"]
+    assert spec.cross_channel_couplings[0].source == "H"
+    assert spec.cross_channel_couplings[0].target == "P"
+
+
 def test_loader_rejects_non_mapping_drivers_block(tmp_path):
     data = {**_SPEC_DATA, "drivers": ["physical"]}
     p = tmp_path / "spec.json"
@@ -209,6 +272,15 @@ def test_loader_rejects_invalid_named_driver_channel(tmp_path):
         load_binding_spec(p)
 
 
+def test_loader_rejects_invalid_declared_channel_id(tmp_path):
+    data = {**_SPEC_DATA, "channels": {"bad channel": {"role": "bad"}}}
+    p = tmp_path / "spec.json"
+    p.write_text(json.dumps(data), encoding="utf-8")
+
+    with pytest.raises(BindingLoadError, match="invalid channel identifier"):
+        load_binding_spec(p)
+
+
 def test_json_yaml_produce_identical_spec(tmp_path):
     """Loading the same spec from JSON and YAML must produce identical BindingSpec."""
     yaml = pytest.importorskip("yaml")
@@ -256,6 +328,39 @@ def test_loaded_spec_passes_validation(tmp_path):
     spec = load_binding_spec(p)
     errors = validate_binding_spec(spec)
     assert errors == [], f"Valid spec should produce no errors: {errors}"
+
+
+def test_validate_rejects_broken_channel_algebra(tmp_path):
+    from scpn_phase_orchestrator.binding import validate_binding_spec
+
+    data = {
+        **_SPEC_DATA,
+        "channels": {
+            "Risk": {
+                "role": "derived_risk",
+                "replay_semantics": "derived",
+                "derived_from": ["Missing"],
+            }
+        },
+        "channel_groups": {"empty": {"channels": []}},
+        "cross_channel_couplings": [
+            {"source": "Risk", "target": "Risk", "strength": -0.1, "mode": "bad"}
+        ],
+    }
+    p = tmp_path / "spec.json"
+    p.write_text(json.dumps(data), encoding="utf-8")
+    spec = load_binding_spec(p)
+
+    errors = validate_binding_spec(spec)
+
+    assert any("derived_from references unknown channel" in err for err in errors)
+    assert any("derive_rule is required" in err for err in errors)
+    assert any(
+        "channel_group 'empty': channels must not be empty" in err for err in errors
+    )
+    assert any("source and target must differ" in err for err in errors)
+    assert any("strength must be finite and >= 0" in err for err in errors)
+    assert any("mode must be one of" in err for err in errors)
 
 
 def test_loader_validate_control_period_and_channels(tmp_path):

--- a/tests/test_binding_resolved.py
+++ b/tests/test_binding_resolved.py
@@ -116,3 +116,82 @@ def test_resolved_binding_config_includes_named_channels(tmp_path):
     assert "H" in summary["channels"]
     assert summary["channels"]["H"]["driver_keys"] == ["cadence_hz"]
     assert any("channel H:" in line for line in lines)
+
+
+def test_resolved_binding_config_includes_channel_algebra(tmp_path):
+    path = _write_spec(
+        tmp_path,
+        {
+            "name": "resolved-nchannel-test",
+            "version": "1.0.0",
+            "safety_tier": "research",
+            "sample_period_s": 0.02,
+            "control_period_s": 0.1,
+            "layers": [
+                {
+                    "name": "plant",
+                    "index": 0,
+                    "oscillator_ids": ["p0"],
+                    "family": "plant",
+                },
+                {
+                    "name": "operator",
+                    "index": 1,
+                    "oscillator_ids": ["h0"],
+                    "family": "operator",
+                },
+                {
+                    "name": "risk",
+                    "index": 2,
+                    "oscillator_ids": ["r0"],
+                    "family": "risk",
+                },
+            ],
+            "oscillator_families": {
+                "plant": {"channel": "P", "extractor_type": "physical", "config": {}},
+                "operator": {"channel": "H", "extractor_type": "event", "config": {}},
+                "risk": {"channel": "Risk", "extractor_type": "graph", "config": {}},
+            },
+            "channels": {
+                "P": {"role": "plant", "units": "rad"},
+                "H": {"role": "operator", "replay_semantics": "event"},
+                "Risk": {
+                    "role": "derived_risk",
+                    "required": False,
+                    "replay_semantics": "derived",
+                    "derived_from": ["P", "H"],
+                    "derive_rule": "phase_lag(P,H)",
+                },
+            },
+            "channel_groups": {
+                "supervised": {
+                    "channels": ["P", "H", "Risk"],
+                    "description": "policy visible channels",
+                }
+            },
+            "cross_channel_couplings": [
+                {"source": "H", "target": "P", "strength": 0.2, "mode": "directed"}
+            ],
+            "coupling": {"base_strength": 0.2, "decay_alpha": 0.1, "templates": {}},
+            "drivers": {
+                "physical": {},
+                "informational": {},
+                "symbolic": {},
+                "H": {"cadence_hz": 2.0},
+                "Risk": {},
+            },
+            "objectives": {"good_layers": [0, 1], "bad_layers": [2]},
+            "boundaries": [],
+            "actuators": [],
+        },
+    )
+
+    summary = resolved_binding_config(load_binding_spec(path))
+    lines = format_resolved_binding_config(summary)
+
+    assert summary["channels"]["Risk"]["derived_from"] == ["P", "H"]
+    assert summary["channels"]["Risk"]["replay_semantics"] == "derived"
+    assert summary["channel_groups"]["supervised"]["channels"] == ["P", "H", "Risk"]
+    assert summary["cross_channel_couplings"][0]["source"] == "H"
+    assert any("metadata: role=derived_risk" in line for line in lines)
+    assert any("channel_groups: supervised" in line for line in lines)

--- a/tests/test_domainpack_validation.py
+++ b/tests/test_domainpack_validation.py
@@ -18,6 +18,11 @@ from scpn_phase_orchestrator.binding.types import VALID_SAFETY_TIERS
 DOMAINPACKS_DIR = Path(__file__).resolve().parent.parent / "domainpacks"
 
 ALL_PACKS = sorted(p.parent.name for p in DOMAINPACKS_DIR.glob("*/binding_spec.yaml"))
+NCHANNEL_EXAMPLES = {
+    "agent_coordination",
+    "swarm_robotics",
+    "traffic_flow",
+}
 
 
 @pytest.fixture(params=ALL_PACKS)
@@ -95,6 +100,18 @@ def test_policy_file_exists(pack_name):
 def test_run_file_exists(pack_name):
     run_path = DOMAINPACKS_DIR / pack_name / "run.py"
     assert run_path.exists(), f"{pack_name}/run.py missing"
+
+
+@pytest.mark.parametrize("pack_name", sorted(NCHANNEL_EXAMPLES))
+def test_nchannel_examples_are_declared_and_wired(pack_name):
+    spec = load_binding_spec(DOMAINPACKS_DIR / pack_name / "binding_spec.yaml")
+
+    assert len(spec.used_channels()) > 3
+    assert spec.channels
+    assert spec.channel_groups
+    assert spec.cross_channel_couplings
+    assert any(channel.derived_from for channel in spec.channels.values())
+    assert validate_binding_spec(spec) == []
 
 
 # Pipeline wiring: domainpack validation tested via real domainpack loading and

--- a/tests/test_rule_engine_parity.py
+++ b/tests/test_rule_engine_parity.py
@@ -241,5 +241,42 @@ def test_compound_and_parity(spo):
     assert len(rust_eng.evaluate("degraded", {"stability_proxy": 0.9})) == 0
 
 
+def test_evaluate_state_good_bad_layer_metric_parity(spo):
+    py_rule = PolicyRule(
+        name="suppress_bad",
+        regimes=["CRITICAL"],
+        condition=PolicyCondition(metric="R_bad", layer=0, op="<", threshold=0.3),
+        actions=[PolicyAction(knob="K", scope="layer_0", value=-0.1, ttl_s=5.0)],
+    )
+    rust_rule = (
+        "suppress_bad",
+        ["CRITICAL"],
+        [("R_bad.0", "<", 0.3)],
+        "AND",
+        [("K", "layer_0", -0.1, 5.0)],
+        0.0,
+        0,
+    )
+    py_eng = PolicyEngine([py_rule])
+    rust_eng = spo.PyRuleEngine([rust_rule])
+    if not hasattr(rust_eng, "evaluate_state"):
+        pytest.skip("installed spo_kernel lacks PyRuleEngine.evaluate_state")
+
+    state = UPDEState(
+        layers=[LayerState(R=0.2, psi=0.0), LayerState(R=0.9, psi=0.0)],
+        cross_layer_alignment=np.zeros((2, 2)),
+        stability_proxy=0.55,
+        regime_id="critical",
+    )
+
+    py_actions = py_eng.evaluate(Regime.CRITICAL, state, [1], [0])
+    rust_actions = rust_eng.evaluate_state("critical", [0.2, 0.9], [1], [0])
+
+    assert len(py_actions) == len(rust_actions) == 1
+    assert py_actions[0].knob == rust_actions[0][0]
+    assert py_actions[0].scope == rust_actions[0][1]
+    assert abs(py_actions[0].value - rust_actions[0][2]) < 1e-12
+
+
 # Pipeline wiring: the parity tests above cross-validate
 # Rust PyRuleEngine against Python PolicyEngine.


### PR DESCRIPTION
## Summary
- add typed N-channel binding metadata, channel groups, derived-channel declarations, and cross-channel coupling declarations
- expose channel algebra in resolved binding summaries and validation diagnostics
- wire three domainpacks as >3-channel examples with derived channels and cross-channel couplings
- extend spo-supervisor RuleEngine with UPDE-state metric context and expose it through PyRuleEngine.evaluate_state

## Validation
- pre-push preflight: PASS all 10 gates
- focused pytest: 431 passed, 1 skipped before full preflight
- cargo check -p spo-ffi
- cargo clippy -p spo-supervisor --all-targets -- -D warnings
- cargo test -p spo-supervisor