### PR TITLE
Add N-channel supervisor roadmap support

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ and is built from source via `maturin develop`.
 | `cardiac_rhythm` | Cardiology | Gap-junction coupling, arrhythmia (4 layers, 10 oscillators) |
 | `chemical_reactor` | Process control | Hopf bifurcation, Semenov limit (4 layers, 10 oscillators) |
 | `circadian_biology` | Chronobiology | SCN clock-gene coupled oscillators (4 layers, 10 oscillators) |
+| `digital_twin_nchannel` | Digital twins | Six-channel plant/twin residual profile with derived `TwinResidual` |
+| `edge_consensus_nchannel` | Edge orchestration | Six-channel gossip consensus with load/trust coupling |
 | `epidemic_sir` | Epidemiology | Epidemic wave synchronisation (3 layers, 8 oscillators) |
 | `firefly_swarm` | Ecology | Flash synchronisation, Mirollo-Strogatz (2 layers, 8 oscillators) |
 | `fusion_equilibrium` | Fusion equilibrium | Grad-Shafranov + FusionCoreBridge (6 layers, 12 oscillators) |
@@ -189,6 +191,7 @@ and is built from source via `maturin develop`.
 | `neuroscience_eeg` | Neuroscience | EEG band->phase, seizure detection (6 layers, 14 oscillators) |
 | `plasma_control` | Tokamak plasma | MHD/transport multi-scale control (8 layers, 16 oscillators) |
 | `pll_clock` | Telecommunications | PLL network clock synchronisation (3 layers, 8 oscillators) |
+| `power_safety_nchannel` | Power systems | Six-channel grid safety profile with derived `Risk` |
 | `power_grid` | Power systems | Swing equation = Kuramoto (5 layers, 12 oscillators) |
 | `quantum_simulation` | Quantum computing | Qubit register phase coupling (3 layers, 8 oscillators) |
 | `queuewaves` | Cloud/queues | Retry storm desynchronisation (3 layers, 6 oscillators) |

--- a/docs/galleries/domainpack_gallery.md
+++ b/docs/galleries/domainpack_gallery.md
@@ -28,7 +28,7 @@ simulations.
 | 18 | **financial_markets** | 8 (4 layers) | Hilbert phase, order parameter regime detection | `18_market_regime_detection.ipynb` |
 | 19 | **swarm_robotics** | 8 (3 layers) | Swarmalator spatial + phase coupling | `19_swarmalator_dynamics.ipynb` |
 
-## All 33 Domainpacks
+## All 36 Domainpacks
 
 | Pack | Domain | Layers | Oscillators | Channels |
 |------|--------|--------|-------------|----------|
@@ -39,6 +39,8 @@ simulations.
 | `cardiac_rhythm` | Cardiology | 4 | 10 | P/I |
 | `chemical_reactor` | Process control | 4 | 10 | P/I |
 | `circadian_biology` | Chronobiology | 4 | 10 | S |
+| `digital_twin_nchannel` | Digital twins | 3 | 6 | P/I/S/Thermal/Quality/TwinResidual |
+| `edge_consensus_nchannel` | Edge orchestration | 3 | 6 | P/I/S/Load/Trust/ConsensusHealth |
 | `epidemic_sir` | Epidemiology | 3 | 8 | P/I |
 | `financial_markets` | Stock sync and crash detection | 4 | 8 | P/I/S |
 | `firefly_swarm` | Ecology | 2 | 8 | P/I |
@@ -55,6 +57,7 @@ simulations.
 | `neuroscience_eeg` | Neuroscience | 6 | 14 | P/I |
 | `plasma_control` | Tokamak plasma | 8 | 16 | P/I |
 | `pll_clock` | Telecommunications | 3 | 8 | P/I |
+| `power_safety_nchannel` | Power systems | 3 | 6 | P/I/S/Reserve/Weather/Risk |
 | `power_grid` | Power systems | 5 | 12 | P/I |
 | `quantum_simulation` | Quantum computing | 3 | 8 | P/I |
 | `queuewaves` | Cloud/queues | 3 | 6 | P/I |

--- a/domainpacks/digital_twin_nchannel/README.md
+++ b/domainpacks/digital_twin_nchannel/README.md
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Commercial license available
+# © Concepts 1996–2026 Miroslav Šotek. All rights reserved.
+# © Code 2020–2026 Miroslav Šotek. All rights reserved.
+# ORCID: 0009-0009-3560-0851
+# Contact: www.anulum.li | protoscience@anulum.li
+# SCPN Phase Orchestrator — Digital Twin N-Channel Domainpack
+
+# Digital Twin N-Channel
+
+This domainpack models a plant and its live digital twin with six
+channels: `P`, `I`, `S`, `Thermal`, `Quality`, and derived
+`TwinResidual`. The residual channel shows how measured phase,
+temperature, and quality streams can be folded into a supervisor-visible
+coherence signal without adding another physical oscillator layer.
+
+Compared with a P/I/S-only binding, `Thermal` and `Quality` make the
+cause of plant/twin divergence explicit, while `TwinResidual` gives
+audit, replay, and policy dry-runs a named derived channel instead of
+burying the residual inside a domain-specific script.

--- a/domainpacks/digital_twin_nchannel/binding_spec.yaml
+++ b/domainpacks/digital_twin_nchannel/binding_spec.yaml
@@ -1,0 +1,153 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Commercial license available
+# © Concepts 1996–2026 Miroslav Šotek. All rights reserved.
+# © Code 2020–2026 Miroslav Šotek. All rights reserved.
+# ORCID: 0009-0009-3560-0851
+# Contact: www.anulum.li | protoscience@anulum.li
+# SCPN Phase Orchestrator — Digital Twin N-Channel Binding Spec
+
+name: digital_twin_nchannel
+version: "0.1.0"
+safety_tier: research
+sample_period_s: 0.01
+control_period_s: 0.1
+
+channels:
+  P:
+    role: machine_phase
+    units: rad
+    metric_semantics: rotating equipment phase and vibration phase lock
+  I:
+    role: event_log
+    units: events/s
+    metric_semantics: maintenance and alarm cadence
+  S:
+    role: operating_state
+    units: state
+    metric_semantics: plant mode state machine
+  Thermal:
+    role: thermal_field
+    units: degC
+    metric_semantics: temperature wave phase across assets
+  Quality:
+    role: quality_stream
+    units: defect_rate
+    metric_semantics: product quality event phase
+  TwinResidual:
+    role: derived_residual
+    required: false
+    units: residual
+    metric_semantics: mismatch between plant and digital twin channels
+    coupling_participation: false
+    replay_semantics: derived
+    derived_from: [P, Thermal, Quality]
+    derive_rule: "abs(P.predicted_phase - P.measured_phase) + Thermal.residual + Quality.residual"
+
+channel_groups:
+  plant_signals:
+    channels: [P, Thermal, Quality]
+    description: live plant measurements
+  decision_signals:
+    channels: [I, S, TwinResidual]
+    description: supervisor-facing context and derived residuals
+
+cross_channel_couplings:
+  - source: Thermal
+    target: P
+    strength: 0.16
+    mode: directed
+    template: thermal_drift_to_machine_phase
+  - source: Quality
+    target: S
+    strength: 0.2
+    mode: directed
+    template: defect_rate_gates_state
+  - source: TwinResidual
+    target: I
+    strength: 0.22
+    mode: excitatory
+    template: residual_raises_event_attention
+
+layers:
+  - name: machine_cells
+    index: 0
+    oscillator_ids: [cell_a, cell_b, cell_c]
+  - name: process_line
+    index: 1
+    oscillator_ids: [line_a, line_b]
+  - name: twin_supervisor
+    index: 2
+    oscillator_ids: [twin]
+
+oscillator_families:
+  rotating_assets:
+    channel: P
+    extractor_type: physical
+    config: {}
+  alarms:
+    channel: I
+    extractor_type: event
+    config: {}
+  operation_state:
+    channel: S
+    extractor_type: ring
+    config:
+      n_states: 5
+  thermal_wave:
+    channel: Thermal
+    extractor_type: wavelet
+    config:
+      window_s: 4.0
+  quality_events:
+    channel: Quality
+    extractor_type: event
+    config:
+      defect_bucket_s: 30.0
+
+coupling:
+  base_strength: 0.48
+  decay_alpha: 0.28
+  templates:
+    thermal_drift_to_machine_phase: thermal_directed
+    defect_rate_gates_state: quality_symbolic
+    residual_raises_event_attention: residual_event
+
+drivers:
+  physical:
+    zeta: 0.01
+    psi: 0.0
+  informational:
+    zeta: 0.02
+  symbolic:
+    zeta: 0.02
+  Thermal:
+    zeta: 0.03
+  Quality:
+    zeta: 0.04
+  TwinResidual:
+    zeta: 0.05
+
+objectives:
+  good_layers: [0, 1, 2]
+  bad_layers: []
+  good_weight: 1.0
+  bad_weight: 1.0
+
+boundaries:
+  - name: twin_residual_floor
+    variable: R_2
+    lower: 0.5
+    upper: null
+    severity: hard
+
+actuators:
+  - name: twin_coupling
+    knob: K
+    scope: global
+    limits: [0.0, 3.0]
+  - name: line_phase_lag
+    knob: alpha
+    scope: layer_1
+    limits: [0.0, 1.0]
+
+policy: policy.yaml

--- a/domainpacks/digital_twin_nchannel/policy.yaml
+++ b/domainpacks/digital_twin_nchannel/policy.yaml
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Commercial license available
+# © Concepts 1996–2026 Miroslav Šotek. All rights reserved.
+# © Code 2020–2026 Miroslav Šotek. All rights reserved.
+# ORCID: 0009-0009-3560-0851
+# Contact: www.anulum.li | protoscience@anulum.li
+# SCPN Phase Orchestrator — Digital Twin N-Channel Policy
+
+rules:
+  - name: reduce_twin_residual
+    regime: [NOMINAL, DEGRADED]
+    priority: 20
+    condition:
+      metric: R_2
+      op: "<"
+      threshold: 0.58
+    actions:
+      - knob: K
+        scope: global
+        value: 0.12
+        ttl_s: 1.0
+    cooldown_s: 0.5
+  - name: stabilise_line_lag
+    regime: [NOMINAL, DEGRADED]
+    priority: 10
+    condition:
+      metric: R_1
+      op: "<"
+      threshold: 0.65
+    actions:
+      - knob: alpha
+        scope: layer_1
+        value: -0.04
+        ttl_s: 1.0
+    cooldown_s: 0.6

--- a/domainpacks/digital_twin_nchannel/run.py
+++ b/domainpacks/digital_twin_nchannel/run.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Commercial license available
+# © Concepts 1996–2026 Miroslav Šotek. All rights reserved.
+# © Code 2020–2026 Miroslav Šotek. All rights reserved.
+# ORCID: 0009-0009-3560-0851
+# Contact: www.anulum.li | protoscience@anulum.li
+# SCPN Phase Orchestrator — Digital twin N-channel example
+
+"""Run the digital-twin N-channel domainpack."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scpn_phase_orchestrator.binding import load_binding_spec, validate_binding_spec
+from scpn_phase_orchestrator.server import SimulationState
+
+STEPS = 50
+SPEC_PATH = Path(__file__).parent / "binding_spec.yaml"
+
+
+def main() -> None:
+    """Run a short deterministic digital-twin simulation."""
+    spec = load_binding_spec(SPEC_PATH)
+    errors = validate_binding_spec(spec)
+    if errors:
+        raise RuntimeError(f"Invalid spec: {errors}")
+
+    sim = SimulationState(spec)
+    print("=== Digital Twin N-Channel ===")
+    print(f"{'step':>5}  {'R_global':>8}  {'regime':>10}")
+    print("-" * 30)
+    for _ in range(STEPS):
+        state = sim.step()
+        if state["step"] % 10 == 0 or state["step"] == 1:
+            print(
+                f"{state['step']:5d}  {state['R_global']:8.4f}  {state['regime']:>10}"
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/domainpacks/edge_consensus_nchannel/README.md
+++ b/domainpacks/edge_consensus_nchannel/README.md
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Commercial license available
+# © Concepts 1996–2026 Miroslav Šotek. All rights reserved.
+# © Code 2020–2026 Miroslav Šotek. All rights reserved.
+# ORCID: 0009-0009-3560-0851
+# Contact: www.anulum.li | protoscience@anulum.li
+# SCPN Phase Orchestrator — Edge Consensus N-Channel Domainpack
+
+# Edge Consensus N-Channel
+
+This domainpack demonstrates a six-channel edge orchestration profile:
+`P`, `I`, `S`, `Load`, `Trust`, and the derived `ConsensusHealth`
+channel. It models local nodes that phase-lock through gossip while
+load pressure and trust scores alter the coupling path.
+
+The example is intentionally compact. Its purpose is to show how
+N-channel bindings declare named channels, groups, derived channels, and
+cross-channel coupling in one runnable binding spec.
+
+Compared with a P/I/S-only binding, the extra channels expose why an edge
+cluster loses coherence: `Load` separates congestion pressure from raw
+phase drift, `Trust` separates peer-quality evidence from event cadence,
+and `ConsensusHealth` gives replay/report tooling one derived safety
+signal to track across the run.

--- a/domainpacks/edge_consensus_nchannel/binding_spec.yaml
+++ b/domainpacks/edge_consensus_nchannel/binding_spec.yaml
@@ -1,0 +1,153 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Commercial license available
+# © Concepts 1996–2026 Miroslav Šotek. All rights reserved.
+# © Code 2020–2026 Miroslav Šotek. All rights reserved.
+# ORCID: 0009-0009-3560-0851
+# Contact: www.anulum.li | protoscience@anulum.li
+# SCPN Phase Orchestrator — Edge Consensus N-Channel Binding Spec
+
+name: edge_consensus_nchannel
+version: "0.1.0"
+safety_tier: research
+sample_period_s: 0.02
+control_period_s: 0.2
+
+channels:
+  P:
+    role: physical_clock
+    units: rad
+    metric_semantics: local oscillator phase lock at each edge node
+  I:
+    role: telemetry_event
+    units: events/s
+    metric_semantics: gossip packet cadence and dropped update bursts
+  S:
+    role: symbolic_mode
+    units: state
+    metric_semantics: node lifecycle state machine
+  Load:
+    role: workload_pressure
+    units: normalised_queue_depth
+    metric_semantics: local queue pressure that modulates consensus urgency
+  Trust:
+    role: peer_trust
+    units: score
+    metric_semantics: reputation-weighted neighbour coherence
+  ConsensusHealth:
+    role: derived_supervisor_metric
+    required: false
+    units: score
+    metric_semantics: derived coherence health from physical lock, telemetry, and trust
+    coupling_participation: false
+    replay_semantics: derived
+    derived_from: [P, I, Trust]
+    derive_rule: "mean(P.lock_quality, I.delivery_ratio, Trust.peer_score)"
+
+channel_groups:
+  realtime_observability:
+    channels: [P, I, Load]
+    description: live signals sampled by each edge node
+  safety_evidence:
+    channels: [S, Trust, ConsensusHealth]
+    description: channels exposed to the supervisor for escalation
+
+cross_channel_couplings:
+  - source: Load
+    target: P
+    strength: 0.18
+    mode: inhibitory
+    template: queue_pressure_desynchronises_clock
+  - source: Trust
+    target: I
+    strength: 0.24
+    mode: directed
+    template: reputation_weights_gossip
+  - source: ConsensusHealth
+    target: S
+    strength: 0.12
+    mode: directed
+    template: derived_health_gates_mode
+
+layers:
+  - name: leaf_nodes
+    index: 0
+    oscillator_ids: [leaf_a, leaf_b, leaf_c]
+  - name: regional_gateways
+    index: 1
+    oscillator_ids: [gateway_a, gateway_b]
+  - name: parent_supervisor
+    index: 2
+    oscillator_ids: [parent]
+
+oscillator_families:
+  clock_phase:
+    channel: P
+    extractor_type: physical
+    config: {}
+  gossip_events:
+    channel: I
+    extractor_type: event
+    config: {}
+  lifecycle_state:
+    channel: S
+    extractor_type: ring
+    config:
+      n_states: 4
+  queue_pressure:
+    channel: Load
+    extractor_type: wavelet
+    config:
+      window_s: 2.0
+  peer_reputation:
+    channel: Trust
+    extractor_type: graph
+    config:
+      edge_weight: trust_score
+
+coupling:
+  base_strength: 0.42
+  decay_alpha: 0.35
+  templates:
+    queue_pressure_desynchronises_clock: inhibitory_load
+    reputation_weights_gossip: trust_directed
+    derived_health_gates_mode: health_to_state
+
+drivers:
+  physical:
+    zeta: 0.01
+    psi: 0.0
+  informational:
+    zeta: 0.03
+  symbolic:
+    zeta: 0.02
+  Load:
+    zeta: 0.04
+  Trust:
+    zeta: 0.02
+  ConsensusHealth:
+    zeta: 0.01
+
+objectives:
+  good_layers: [0, 1, 2]
+  bad_layers: []
+  good_weight: 1.0
+  bad_weight: 1.0
+
+boundaries:
+  - name: parent_lock_floor
+    variable: R_2
+    lower: 0.55
+    upper: null
+    severity: soft
+
+actuators:
+  - name: edge_coupling
+    knob: K
+    scope: global
+    limits: [0.0, 2.5]
+  - name: gateway_lag
+    knob: alpha
+    scope: layer_1
+    limits: [0.0, 1.2]
+
+policy: policy.yaml

--- a/domainpacks/edge_consensus_nchannel/policy.yaml
+++ b/domainpacks/edge_consensus_nchannel/policy.yaml
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Commercial license available
+# © Concepts 1996–2026 Miroslav Šotek. All rights reserved.
+# © Code 2020–2026 Miroslav Šotek. All rights reserved.
+# ORCID: 0009-0009-3560-0851
+# Contact: www.anulum.li | protoscience@anulum.li
+# SCPN Phase Orchestrator — Edge Consensus N-Channel Policy
+
+rules:
+  - name: reinforce_gateway_lock
+    regime: [NOMINAL, DEGRADED]
+    priority: 20
+    condition:
+      metric: R_good
+      op: "<"
+      threshold: 0.72
+    actions:
+      - knob: K
+        scope: global
+        value: 0.14
+        ttl_s: 1.0
+    cooldown_s: 0.4
+  - name: damp_gateway_lag
+    regime: [NOMINAL, DEGRADED]
+    priority: 10
+    logic: AND
+    conditions:
+      - metric: R_1
+        op: "<"
+        threshold: 0.68
+      - metric: R_global
+        op: "<"
+        threshold: 0.75
+    actions:
+      - knob: alpha
+        scope: layer_1
+        value: -0.05
+        ttl_s: 1.0
+    cooldown_s: 0.6

--- a/domainpacks/edge_consensus_nchannel/run.py
+++ b/domainpacks/edge_consensus_nchannel/run.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Commercial license available
+# © Concepts 1996–2026 Miroslav Šotek. All rights reserved.
+# © Code 2020–2026 Miroslav Šotek. All rights reserved.
+# ORCID: 0009-0009-3560-0851
+# Contact: www.anulum.li | protoscience@anulum.li
+# SCPN Phase Orchestrator — Edge consensus N-channel example
+
+"""Run the edge-consensus N-channel domainpack."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scpn_phase_orchestrator.binding import load_binding_spec, validate_binding_spec
+from scpn_phase_orchestrator.server import SimulationState
+
+STEPS = 50
+SPEC_PATH = Path(__file__).parent / "binding_spec.yaml"
+
+
+def main() -> None:
+    """Run a short deterministic edge-consensus simulation."""
+    spec = load_binding_spec(SPEC_PATH)
+    errors = validate_binding_spec(spec)
+    if errors:
+        raise RuntimeError(f"Invalid spec: {errors}")
+
+    sim = SimulationState(spec)
+    print("=== Edge Consensus N-Channel ===")
+    print(f"{'step':>5}  {'R_global':>8}  {'regime':>10}")
+    print("-" * 30)
+    for _ in range(STEPS):
+        state = sim.step()
+        if state["step"] % 10 == 0 or state["step"] == 1:
+            print(
+                f"{state['step']:5d}  {state['R_global']:8.4f}  {state['regime']:>10}"
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/domainpacks/power_safety_nchannel/README.md
+++ b/domainpacks/power_safety_nchannel/README.md
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Commercial license available
+# © Concepts 1996–2026 Miroslav Šotek. All rights reserved.
+# © Code 2020–2026 Miroslav Šotek. All rights reserved.
+# ORCID: 0009-0009-3560-0851
+# Contact: www.anulum.li | protoscience@anulum.li
+# SCPN Phase Orchestrator — Power Safety N-Channel Domainpack
+
+# Power Safety N-Channel
+
+This domainpack extends the power-grid profile beyond `P`, `I`, and `S`
+with `Reserve`, `Weather`, and derived `Risk` channels. It is a compact
+example of cross-channel safety evidence where weather forcing perturbs
+grid phase, reserve margin suppresses risk, and risk gates symbolic grid
+state transitions.
+
+Compared with a P/I/S-only binding, the extra channels keep forecast
+forcing, reserve headroom, and derived safety pressure separate. That
+lets policy rules distinguish a phase-lock loss caused by exogenous
+weather from one caused by insufficient reserve.

--- a/domainpacks/power_safety_nchannel/binding_spec.yaml
+++ b/domainpacks/power_safety_nchannel/binding_spec.yaml
@@ -1,0 +1,153 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Commercial license available
+# © Concepts 1996–2026 Miroslav Šotek. All rights reserved.
+# © Code 2020–2026 Miroslav Šotek. All rights reserved.
+# ORCID: 0009-0009-3560-0851
+# Contact: www.anulum.li | protoscience@anulum.li
+# SCPN Phase Orchestrator — Power Safety N-Channel Binding Spec
+
+name: power_safety_nchannel
+version: "0.1.0"
+safety_tier: research
+sample_period_s: 0.02
+control_period_s: 0.2
+
+channels:
+  P:
+    role: electrical_phase
+    units: rad
+    metric_semantics: voltage and frequency synchronisation
+  I:
+    role: protection_events
+    units: events/s
+    metric_semantics: relay and breaker event cadence
+  S:
+    role: grid_state
+    units: state
+    metric_semantics: grid operating mode
+  Reserve:
+    role: spinning_reserve
+    units: MW
+    metric_semantics: reserve margin phase pressure
+  Weather:
+    role: weather_forcing
+    units: normalised_forecast
+    metric_semantics: forecast-driven renewable volatility
+  Risk:
+    role: derived_risk
+    required: false
+    units: score
+    metric_semantics: derived safety pressure from reserve, weather, and events
+    coupling_participation: false
+    replay_semantics: derived
+    derived_from: [Reserve, Weather, I]
+    derive_rule: "max(0, Weather.volatility - Reserve.margin) + I.trip_rate"
+
+channel_groups:
+  grid_observability:
+    channels: [P, Reserve, Weather]
+    description: continuous grid physics and exogenous forcing
+  safety_channels:
+    channels: [I, S, Risk]
+    description: protection and supervisor decision evidence
+
+cross_channel_couplings:
+  - source: Weather
+    target: P
+    strength: 0.14
+    mode: excitatory
+    template: weather_forces_grid_phase
+  - source: Reserve
+    target: Risk
+    strength: 0.2
+    mode: inhibitory
+    template: reserve_suppresses_risk
+  - source: Risk
+    target: S
+    strength: 0.3
+    mode: directed
+    template: risk_gates_grid_state
+
+layers:
+  - name: feeders
+    index: 0
+    oscillator_ids: [feeder_a, feeder_b, feeder_c]
+  - name: substations
+    index: 1
+    oscillator_ids: [substation_a, substation_b]
+  - name: regional_dispatch
+    index: 2
+    oscillator_ids: [dispatch]
+
+oscillator_families:
+  electrical_phase:
+    channel: P
+    extractor_type: physical
+    config: {}
+  protection_log:
+    channel: I
+    extractor_type: event
+    config: {}
+  operating_state:
+    channel: S
+    extractor_type: ring
+    config:
+      n_states: 4
+  reserve_margin:
+    channel: Reserve
+    extractor_type: zero_crossing
+    config:
+      centred_on: scheduled_margin
+  weather_forcing:
+    channel: Weather
+    extractor_type: wavelet
+    config:
+      horizon_s: 900.0
+
+coupling:
+  base_strength: 0.5
+  decay_alpha: 0.32
+  templates:
+    weather_forces_grid_phase: weather_phase
+    reserve_suppresses_risk: reserve_risk
+    risk_gates_grid_state: risk_state
+
+drivers:
+  physical:
+    zeta: 0.01
+    psi: 0.0
+  informational:
+    zeta: 0.03
+  symbolic:
+    zeta: 0.02
+  Reserve:
+    zeta: 0.02
+  Weather:
+    zeta: 0.05
+  Risk:
+    zeta: 0.04
+
+objectives:
+  good_layers: [0, 1, 2]
+  bad_layers: []
+  good_weight: 1.0
+  bad_weight: 1.0
+
+boundaries:
+  - name: dispatch_lock_floor
+    variable: R_2
+    lower: 0.52
+    upper: null
+    severity: hard
+
+actuators:
+  - name: grid_coupling
+    knob: K
+    scope: global
+    limits: [0.0, 3.0]
+  - name: substation_lag
+    knob: alpha
+    scope: layer_1
+    limits: [0.0, 1.0]
+
+policy: policy.yaml

--- a/domainpacks/power_safety_nchannel/policy.yaml
+++ b/domainpacks/power_safety_nchannel/policy.yaml
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Commercial license available
+# © Concepts 1996–2026 Miroslav Šotek. All rights reserved.
+# © Code 2020–2026 Miroslav Šotek. All rights reserved.
+# ORCID: 0009-0009-3560-0851
+# Contact: www.anulum.li | protoscience@anulum.li
+# SCPN Phase Orchestrator — Power Safety N-Channel Policy
+
+rules:
+  - name: reinforce_dispatch_coherence
+    regime: [NOMINAL, DEGRADED]
+    priority: 20
+    condition:
+      metric: R_good
+      op: "<"
+      threshold: 0.7
+    actions:
+      - knob: K
+        scope: global
+        value: 0.15
+        ttl_s: 1.0
+    cooldown_s: 0.4
+  - name: reduce_substation_lag
+    regime: [NOMINAL, DEGRADED]
+    priority: 10
+    condition:
+      metric: R_1
+      op: "<"
+      threshold: 0.63
+    actions:
+      - knob: alpha
+        scope: layer_1
+        value: -0.04
+        ttl_s: 1.0
+    cooldown_s: 0.6

--- a/domainpacks/power_safety_nchannel/run.py
+++ b/domainpacks/power_safety_nchannel/run.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Commercial license available
+# © Concepts 1996–2026 Miroslav Šotek. All rights reserved.
+# © Code 2020–2026 Miroslav Šotek. All rights reserved.
+# ORCID: 0009-0009-3560-0851
+# Contact: www.anulum.li | protoscience@anulum.li
+# SCPN Phase Orchestrator — Power safety N-channel example
+
+"""Run the power-safety N-channel domainpack."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scpn_phase_orchestrator.binding import load_binding_spec, validate_binding_spec
+from scpn_phase_orchestrator.server import SimulationState
+
+STEPS = 50
+SPEC_PATH = Path(__file__).parent / "binding_spec.yaml"
+
+
+def main() -> None:
+    """Run a short deterministic power-safety simulation."""
+    spec = load_binding_spec(SPEC_PATH)
+    errors = validate_binding_spec(spec)
+    if errors:
+        raise RuntimeError(f"Invalid spec: {errors}")
+
+    sim = SimulationState(spec)
+    print("=== Power Safety N-Channel ===")
+    print(f"{'step':>5}  {'R_global':>8}  {'regime':>10}")
+    print("-" * 30)
+    for _ in range(STEPS):
+        state = sim.step()
+        if state["step"] % 10 == 0 or state["step"] == 1:
+            print(
+                f"{state['step']:5d}  {state['R_global']:8.4f}  {state['regime']:>10}"
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/spo-kernel/crates/spo-ffi/src/lib.rs
+++ b/spo-kernel/crates/spo-ffi/src/lib.rs
@@ -1649,15 +1649,20 @@ impl PyRuleEngine {
                             })
                         })
                         .collect::<PyResult<Vec<_>>>()?;
+                    let logic = match logic.to_uppercase().as_str() {
+                        "AND" => rule_engine::Logic::And,
+                        "OR" => rule_engine::Logic::Or,
+                        other => {
+                            return Err(PyValueError::new_err(format!(
+                                "unknown rule logic: {other}"
+                            )))
+                        }
+                    };
                     let condition = if conditions.len() == 1 {
                         rule_engine::RuleCondition::Single(
                             conditions.into_iter().next().expect("len==1"),
                         )
                     } else {
-                        let logic = match logic.to_uppercase().as_str() {
-                            "OR" => rule_engine::Logic::Or,
-                            _ => rule_engine::Logic::And,
-                        };
                         rule_engine::RuleCondition::Compound { conditions, logic }
                     };
                     let rule_actions: Vec<rule_engine::RuleAction> = actions
@@ -1681,7 +1686,7 @@ impl PyRuleEngine {
             )
             .collect::<PyResult<Vec<_>>>()?;
         Ok(Self {
-            inner: rule_engine::RuleEngine::new(parsed),
+            inner: rule_engine::RuleEngine::try_new(parsed).map_err(PyValueError::new_err)?,
         })
     }
 
@@ -1728,6 +1733,29 @@ impl PyRuleEngine {
     #[getter]
     fn clock(&self) -> f64 {
         self.inner.clock()
+    }
+
+    #[getter]
+    fn rule_names(&self) -> Vec<String> {
+        self.inner.rule_names()
+    }
+
+    fn fire_count(&self, rule_name: &str) -> u32 {
+        self.inner.fire_count(rule_name)
+    }
+
+    #[getter]
+    fn fire_counts(&self) -> HashMap<String, u32> {
+        self.inner.fire_counts().clone()
+    }
+
+    fn last_fire_time(&self, rule_name: &str) -> Option<f64> {
+        self.inner.last_fire_time(rule_name)
+    }
+
+    #[getter]
+    fn last_fire_times(&self) -> HashMap<String, f64> {
+        self.inner.last_fire_times().clone()
     }
 }
 
@@ -1822,6 +1850,23 @@ impl PyPetriNet {
     fn place_names(&self) -> Vec<String> {
         self.inner.place_names().to_vec()
     }
+
+    #[getter]
+    fn transition_names(&self) -> Vec<String> {
+        self.inner.transition_names()
+    }
+
+    fn active_places(&self, tokens: HashMap<String, u32>) -> Vec<String> {
+        let mut marking = petri_net::Marking::default();
+        for (p, n) in &tokens {
+            marking.set(p, *n);
+        }
+        marking
+            .active_places()
+            .into_iter()
+            .map(str::to_string)
+            .collect()
+    }
 }
 
 // ─── Helpers ────────────────────────────────────────────────────────
@@ -1846,6 +1891,7 @@ fn make_upde_state_full(layer_rs: &[f64], psi_values: &[f64], cla: &[f64]) -> UP
     };
     UPDEState {
         layers,
+        channel_metrics: vec![],
         cross_layer_alignment: cla.to_vec(),
         stability_proxy,
         regime: Regime::Nominal,

--- a/spo-kernel/crates/spo-supervisor/src/coherence.rs
+++ b/spo-kernel/crates/spo-supervisor/src/coherence.rs
@@ -75,6 +75,7 @@ mod tests {
     fn make_state(rs: &[f64]) -> UPDEState {
         UPDEState {
             layers: rs.iter().map(|&r| LayerState { r, psi: 0.0 }).collect(),
+            channel_metrics: vec![],
             cross_layer_alignment: vec![],
             stability_proxy: 0.0,
             regime: Regime::Nominal,
@@ -107,6 +108,7 @@ mod tests {
     fn make_state_with_cla(rs: &[f64], cla: Vec<f64>) -> UPDEState {
         UPDEState {
             layers: rs.iter().map(|&r| LayerState { r, psi: 0.0 }).collect(),
+            channel_metrics: vec![],
             cross_layer_alignment: cla,
             stability_proxy: 0.0,
             regime: Regime::Nominal,

--- a/spo-kernel/crates/spo-supervisor/src/petri_net.rs
+++ b/spo-kernel/crates/spo-supervisor/src/petri_net.rs
@@ -42,6 +42,9 @@ impl Guard {
         let Some(&val) = ctx.get(&self.metric) else {
             return false;
         };
+        if !val.is_finite() || !self.threshold.is_finite() {
+            return false;
+        }
         match self.op {
             GuardOp::Gt => val > self.threshold,
             GuardOp::Ge => val >= self.threshold,
@@ -105,8 +108,22 @@ impl PetriNet {
     /// # Errors
     /// Returns error if any arc references an unknown place.
     pub fn new(places: Vec<String>, transitions: Vec<Transition>) -> Result<Self, String> {
+        for place in &places {
+            if place.is_empty() {
+                return Err("place names must not be empty".into());
+            }
+        }
         for t in &transitions {
+            if t.name.is_empty() {
+                return Err("transition names must not be empty".into());
+            }
             for arc in t.inputs.iter().chain(t.outputs.iter()) {
+                if arc.weight == 0 {
+                    return Err(format!(
+                        "transition {:?} has zero-weight arc for place {:?}",
+                        t.name, arc.place
+                    ));
+                }
                 if !places.contains(&arc.place) {
                     return Err(format!(
                         "transition {:?} references unknown place {:?}",
@@ -129,6 +146,14 @@ impl PetriNet {
     #[must_use]
     pub fn transitions(&self) -> &[Transition] {
         &self.transitions
+    }
+
+    #[must_use]
+    pub fn transition_names(&self) -> Vec<String> {
+        self.transitions
+            .iter()
+            .map(|transition| transition.name.clone())
+            .collect()
     }
 
     #[must_use]
@@ -199,6 +224,9 @@ pub fn parse_guard(text: &str) -> Result<Guard, String> {
     let threshold: f64 = parts[2]
         .parse()
         .map_err(|e| format!("invalid threshold: {e}"))?;
+    if !threshold.is_finite() {
+        return Err(format!("guard threshold must be finite, got {threshold}"));
+    }
     Ok(Guard {
         metric: parts[0].to_string(),
         op,
@@ -317,6 +345,43 @@ mod tests {
     }
 
     #[test]
+    fn empty_place_rejected() {
+        let result = PetriNet::new(vec!["".into()], vec![]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn empty_transition_rejected() {
+        let result = PetriNet::new(
+            vec!["a".into()],
+            vec![Transition {
+                name: String::new(),
+                inputs: vec![],
+                outputs: vec![],
+                guard: None,
+            }],
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn zero_weight_arc_rejected() {
+        let result = PetriNet::new(
+            vec!["a".into()],
+            vec![Transition {
+                name: "bad".into(),
+                inputs: vec![Arc {
+                    place: "a".into(),
+                    weight: 0,
+                }],
+                outputs: vec![],
+                guard: None,
+            }],
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
     fn parse_guard_valid() {
         let g = parse_guard("stability_proxy > 0.6").expect("valid");
         assert_eq!(g.metric, "stability_proxy");
@@ -345,6 +410,12 @@ mod tests {
     }
 
     #[test]
+    fn parse_guard_rejects_non_finite_threshold() {
+        assert!(parse_guard("x > NaN").is_err());
+        assert!(parse_guard("x > inf").is_err());
+    }
+
+    #[test]
     fn guard_evaluate_missing_metric() {
         let g = Guard {
             metric: "missing".into(),
@@ -352,6 +423,26 @@ mod tests {
             threshold: 0.5,
         };
         assert!(!g.evaluate(&HashMap::new()));
+    }
+
+    #[test]
+    fn guard_rejects_non_finite_context_metric() {
+        let g = Guard {
+            metric: "x".into(),
+            op: GuardOp::Gt,
+            threshold: 0.5,
+        };
+        let ctx: HashMap<String, f64> = [("x".into(), f64::INFINITY)].into();
+        assert!(!g.evaluate(&ctx));
+    }
+
+    #[test]
+    fn transition_names_preserve_priority_order() {
+        let net = simple_net();
+        assert_eq!(
+            net.transition_names(),
+            vec!["start".to_string(), "finish".to_string()]
+        );
     }
 
     #[test]

--- a/spo-kernel/crates/spo-supervisor/src/policy.rs
+++ b/spo-kernel/crates/spo-supervisor/src/policy.rs
@@ -91,6 +91,7 @@ mod tests {
     fn make_state(r: f64) -> UPDEState {
         UPDEState {
             layers: vec![LayerState { r, psi: 0.0 }; 4],
+            channel_metrics: vec![],
             cross_layer_alignment: vec![],
             stability_proxy: 0.0,
             regime: Regime::Nominal,
@@ -134,6 +135,7 @@ mod tests {
                 LayerState { r: 0.05, psi: 0.0 },
                 LayerState { r: 0.1, psi: 0.0 },
             ],
+            channel_metrics: vec![],
             cross_layer_alignment: vec![],
             stability_proxy: 0.0,
             regime: Regime::Nominal,
@@ -170,6 +172,7 @@ mod tests {
                 },
                 LayerState { r: 0.2, psi: 0.0 },
             ],
+            channel_metrics: vec![],
             cross_layer_alignment: vec![],
             stability_proxy: 0.0,
             regime: Regime::Nominal,
@@ -190,6 +193,7 @@ mod tests {
                     psi: 0.0,
                 },
             ],
+            channel_metrics: vec![],
             cross_layer_alignment: vec![],
             stability_proxy: 0.0,
             regime: Regime::Nominal,

--- a/spo-kernel/crates/spo-supervisor/src/regime.rs
+++ b/spo-kernel/crates/spo-supervisor/src/regime.rs
@@ -186,6 +186,7 @@ mod tests {
     fn make_state(r: f64) -> UPDEState {
         UPDEState {
             layers: vec![LayerState { r, psi: 0.0 }],
+            channel_metrics: vec![],
             cross_layer_alignment: vec![],
             stability_proxy: 0.0,
             regime: Regime::Nominal,
@@ -283,6 +284,7 @@ mod tests {
         let rm = RegimeManager::default();
         let state = UPDEState {
             layers: vec![],
+            channel_metrics: vec![],
             cross_layer_alignment: vec![],
             stability_proxy: 0.0,
             regime: Regime::Nominal,

--- a/spo-kernel/crates/spo-supervisor/src/rule_engine.rs
+++ b/spo-kernel/crates/spo-supervisor/src/rule_engine.rs
@@ -28,6 +28,9 @@ impl Condition {
         let Some(&val) = ctx.get(&self.metric) else {
             return false;
         };
+        if !val.is_finite() {
+            return false;
+        }
         match self.op {
             GuardOp::Gt => val > self.threshold,
             GuardOp::Ge => val >= self.threshold,
@@ -97,6 +100,7 @@ pub struct FiredAction {
 }
 
 /// Rule-based policy engine with cooldown and fire-count tracking.
+#[derive(Debug)]
 pub struct RuleEngine {
     rules: Vec<PolicyRule>,
     fire_counts: HashMap<String, u32>,
@@ -105,14 +109,32 @@ pub struct RuleEngine {
 }
 
 impl RuleEngine {
+    /// Build a rule engine, panicking if rules are invalid.
+    ///
+    /// # Panics
+    /// Panics when `rules` contains non-finite thresholds/action values,
+    /// negative TTL/cooldown values, empty action fields, or empty condition
+    /// metrics. Use [`Self::try_new`] when policy input is user supplied.
     #[must_use]
     pub fn new(rules: Vec<PolicyRule>) -> Self {
-        Self {
+        Self::try_new(rules).expect("valid policy rules")
+    }
+
+    /// Build a rule engine after validating the policy surface.
+    ///
+    /// # Errors
+    /// Returns a human-readable error when rule thresholds, action values,
+    /// TTLs, or cooldowns are non-finite or outside their valid ranges.
+    pub fn try_new(rules: Vec<PolicyRule>) -> Result<Self, String> {
+        for rule in &rules {
+            validate_rule(rule)?;
+        }
+        Ok(Self {
             rules,
             fire_counts: HashMap::new(),
             last_fire_t: HashMap::new(),
             clock: 0.0,
-        }
+        })
     }
 
     pub fn advance_clock(&mut self, dt: f64) {
@@ -122,6 +144,36 @@ impl RuleEngine {
     #[must_use]
     pub fn clock(&self) -> f64 {
         self.clock
+    }
+
+    /// Return policy rule names in evaluation order.
+    #[must_use]
+    pub fn rule_names(&self) -> Vec<String> {
+        self.rules.iter().map(|rule| rule.name.clone()).collect()
+    }
+
+    /// Return the number of times a rule has fired.
+    #[must_use]
+    pub fn fire_count(&self, rule_name: &str) -> u32 {
+        self.fire_counts.get(rule_name).copied().unwrap_or(0)
+    }
+
+    /// Return all recorded fire counts keyed by rule name.
+    #[must_use]
+    pub fn fire_counts(&self) -> &HashMap<String, u32> {
+        &self.fire_counts
+    }
+
+    /// Return the last engine-clock time at which a rule fired.
+    #[must_use]
+    pub fn last_fire_time(&self, rule_name: &str) -> Option<f64> {
+        self.last_fire_t.get(rule_name).copied()
+    }
+
+    /// Return all recorded last-fire times keyed by rule name.
+    #[must_use]
+    pub fn last_fire_times(&self) -> &HashMap<String, f64> {
+        &self.last_fire_t
     }
 
     /// Evaluate all rules against regime + metric context. Returns fired actions.
@@ -185,6 +237,80 @@ impl RuleEngine {
     }
 }
 
+fn validate_rule(rule: &PolicyRule) -> Result<(), String> {
+    if rule.name.is_empty() {
+        return Err("policy rule name must not be empty".into());
+    }
+    validate_condition(&rule.condition)?;
+    if !rule.cooldown_s.is_finite() || rule.cooldown_s < 0.0 {
+        return Err(format!(
+            "policy rule {:?}: cooldown_s must be finite and >= 0",
+            rule.name
+        ));
+    }
+    if rule.actions.is_empty() {
+        return Err(format!(
+            "policy rule {:?}: actions must not be empty",
+            rule.name
+        ));
+    }
+    for action in &rule.actions {
+        if action.knob.is_empty() {
+            return Err(format!(
+                "policy rule {:?}: action knob must not be empty",
+                rule.name
+            ));
+        }
+        if action.scope.is_empty() {
+            return Err(format!(
+                "policy rule {:?}: action scope must not be empty",
+                rule.name
+            ));
+        }
+        if !action.value.is_finite() {
+            return Err(format!(
+                "policy rule {:?}: action value must be finite",
+                rule.name
+            ));
+        }
+        if !action.ttl_s.is_finite() || action.ttl_s < 0.0 {
+            return Err(format!(
+                "policy rule {:?}: action ttl_s must be finite and >= 0",
+                rule.name
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_condition(condition: &RuleCondition) -> Result<(), String> {
+    match condition {
+        RuleCondition::Single(condition) => validate_single_condition(condition),
+        RuleCondition::Compound { conditions, .. } => {
+            if conditions.is_empty() {
+                return Err("compound policy condition must not be empty".into());
+            }
+            for condition in conditions {
+                validate_single_condition(condition)?;
+            }
+            Ok(())
+        }
+    }
+}
+
+fn validate_single_condition(condition: &Condition) -> Result<(), String> {
+    if condition.metric.is_empty() {
+        return Err("policy condition metric must not be empty".into());
+    }
+    if !condition.threshold.is_finite() {
+        return Err(format!(
+            "policy condition {:?}: threshold must be finite",
+            condition.metric
+        ));
+    }
+    Ok(())
+}
+
 /// Build the metric context used by rule evaluation from a UPDE state.
 #[must_use]
 pub fn state_context(
@@ -217,13 +343,23 @@ pub fn state_context(
         }
     }
 
+    for metric in &state.channel_metrics {
+        let channel = metric.channel.as_str();
+        ctx.insert(format!("R.channel.{channel}"), metric.r);
+        ctx.insert(format!("R_channel_{channel}"), metric.r);
+        ctx.insert(format!("psi.channel.{channel}"), metric.psi);
+        ctx.insert(format!("psi_channel_{channel}"), metric.psi);
+        ctx.insert(format!("channel_weight.{channel}"), metric.weight);
+        ctx.insert(format!("channel_weight_{channel}"), metric.weight);
+    }
+
     ctx
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use spo_types::{LayerState, Regime, UPDEState};
+    use spo_types::{Channel, ChannelMetric, LayerState, Regime, UPDEState};
 
     fn simple_rule(name: &str, regime: &str, metric: &str, op: GuardOp, thresh: f64) -> PolicyRule {
         PolicyRule {
@@ -252,6 +388,21 @@ mod tests {
                 .copied()
                 .map(|r| LayerState { r, psi: 0.0 })
                 .collect(),
+            channel_metrics: vec![],
+            cross_layer_alignment: vec![],
+            stability_proxy: 0.42,
+            regime: Regime::Nominal,
+        }
+    }
+
+    fn state_with_channels(rs: &[f64], channel_metrics: Vec<ChannelMetric>) -> UPDEState {
+        UPDEState {
+            layers: rs
+                .iter()
+                .copied()
+                .map(|r| LayerState { r, psi: 0.0 })
+                .collect(),
+            channel_metrics,
             cross_layer_alignment: vec![],
             stability_proxy: 0.42,
             regime: Regime::Nominal,
@@ -274,6 +425,54 @@ mod tests {
     }
 
     #[test]
+    fn try_new_rejects_non_finite_threshold() {
+        let err = RuleEngine::try_new(vec![simple_rule(
+            "bad",
+            "DEGRADED",
+            "stability_proxy",
+            GuardOp::Lt,
+            f64::NAN,
+        )])
+        .expect_err("NaN threshold must be rejected");
+
+        assert!(err.contains("threshold must be finite"));
+    }
+
+    #[test]
+    fn try_new_rejects_bad_action_values() {
+        let mut rule = simple_rule("bad_action", "DEGRADED", "x", GuardOp::Lt, 1.0);
+        rule.actions[0].ttl_s = -1.0;
+
+        let err = RuleEngine::try_new(vec![rule]).expect_err("negative TTL must be rejected");
+
+        assert!(err.contains("ttl_s must be finite and >= 0"));
+    }
+
+    #[test]
+    fn try_new_rejects_empty_actions() {
+        let mut rule = simple_rule("no_action", "DEGRADED", "x", GuardOp::Lt, 1.0);
+        rule.actions.clear();
+
+        let err = RuleEngine::try_new(vec![rule]).expect_err("empty actions must fail");
+
+        assert!(err.contains("actions must not be empty"));
+    }
+
+    #[test]
+    fn non_finite_context_metric_does_not_fire() {
+        let mut eng = RuleEngine::new(vec![simple_rule(
+            "boost",
+            "DEGRADED",
+            "stability_proxy",
+            GuardOp::Gt,
+            0.5,
+        )]);
+        let ctx: HashMap<String, f64> = [("stability_proxy".into(), f64::INFINITY)].into();
+
+        assert!(eng.evaluate("degraded", &ctx).is_empty());
+    }
+
+    #[test]
     fn state_context_exposes_layer_and_partition_metrics() {
         let ctx = state_context(&state(&[0.2, 0.8, 0.4]), &[1], &[0, 2], &HashMap::new());
 
@@ -285,6 +484,25 @@ mod tests {
     }
 
     #[test]
+    fn state_context_exposes_named_channel_metrics() {
+        let state = state_with_channels(
+            &[0.2, 0.8, 0.4],
+            vec![
+                ChannelMetric::new(Channel::P, 0.75, 1.0, 1.0).expect("valid P metric"),
+                ChannelMetric::new(Channel::new("Risk"), 0.25, 2.0, 0.5)
+                    .expect("valid Risk metric"),
+            ],
+        );
+
+        let ctx = state_context(&state, &[], &[], &HashMap::new());
+
+        assert_eq!(ctx["R.channel.P"], 0.75);
+        assert_eq!(ctx["R_channel_Risk"], 0.25);
+        assert_eq!(ctx["psi.channel.Risk"], 2.0);
+        assert_eq!(ctx["channel_weight_Risk"], 0.5);
+    }
+
+    #[test]
     fn evaluate_state_uses_good_bad_layer_metrics() {
         let rule = simple_rule("suppress_bad", "CRITICAL", "R_bad.0", GuardOp::Lt, 0.3);
         let mut eng = RuleEngine::new(vec![rule]);
@@ -293,6 +511,22 @@ mod tests {
 
         assert_eq!(actions.len(), 1);
         assert_eq!(actions[0].rule_name, "suppress_bad");
+    }
+
+    #[test]
+    fn evaluate_state_uses_named_channel_metrics() {
+        let rule = simple_rule("risk_guard", "CRITICAL", "R.channel.Risk", GuardOp::Lt, 0.3);
+        let mut eng = RuleEngine::new(vec![rule]);
+        let state = state_with_channels(
+            &[0.2, 0.9],
+            vec![ChannelMetric::new(Channel::new("Risk"), 0.25, 2.0, 0.5)
+                .expect("valid Risk metric")],
+        );
+
+        let actions = eng.evaluate_state("critical", &state, &[], &[], &HashMap::new());
+
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0].rule_name, "risk_guard");
     }
 
     #[test]
@@ -350,6 +584,33 @@ mod tests {
         assert_eq!(eng.evaluate("degraded", &ctx).len(), 1);
         assert_eq!(eng.evaluate("degraded", &ctx).len(), 1);
         assert!(eng.evaluate("degraded", &ctx).is_empty()); // max_fires reached
+    }
+
+    #[test]
+    fn exposes_rule_fire_diagnostics() {
+        let rule = PolicyRule {
+            max_fires: 2,
+            cooldown_s: 0.5,
+            ..simple_rule("r1", "DEGRADED", "x", GuardOp::Lt, 1.0)
+        };
+        let mut eng = RuleEngine::new(vec![rule]);
+        let ctx: HashMap<String, f64> = [("x".into(), 0.5)].into();
+
+        assert_eq!(eng.rule_names(), vec!["r1".to_string()]);
+        assert_eq!(eng.fire_count("r1"), 0);
+        assert_eq!(eng.last_fire_time("r1"), None);
+
+        assert_eq!(eng.evaluate("degraded", &ctx).len(), 1);
+
+        assert_eq!(eng.fire_count("r1"), 1);
+        assert_eq!(eng.fire_counts()["r1"], 1);
+        assert_eq!(eng.last_fire_time("r1"), Some(0.0));
+        assert_eq!(eng.last_fire_times()["r1"], 0.0);
+
+        eng.advance_clock(1.0);
+        assert_eq!(eng.evaluate("degraded", &ctx).len(), 1);
+        assert_eq!(eng.fire_count("r1"), 2);
+        assert_eq!(eng.last_fire_time("r1"), Some(1.0));
     }
 
     #[test]

--- a/spo-kernel/crates/spo-types/src/lib.rs
+++ b/spo-kernel/crates/spo-types/src/lib.rs
@@ -17,4 +17,4 @@ pub mod state;
 pub use action::{ControlAction, Knob, Regime};
 pub use config::{CouplingConfig, IntegrationConfig, Method};
 pub use error::{SpoError, SpoResult};
-pub use state::{Channel, LayerState, PhaseState, UPDEState};
+pub use state::{Channel, ChannelMetric, LayerState, PhaseState, UPDEState};

--- a/spo-kernel/crates/spo-types/src/state.rs
+++ b/spo-kernel/crates/spo-types/src/state.rs
@@ -6,15 +6,136 @@
 // Contact: www.anulum.li | protoscience@anulum.li
 // SCPN Phase Orchestrator — State types
 
-use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::action::Regime;
+use crate::error::{SpoError, SpoResult};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Channel {
     P,
     I,
     S,
+    Custom(String),
+}
+
+impl Channel {
+    #[must_use]
+    pub fn new(id: impl Into<String>) -> Self {
+        match id.into().as_str() {
+            "P" => Self::P,
+            "I" => Self::I,
+            "S" => Self::S,
+            other => Self::Custom(other.to_owned()),
+        }
+    }
+
+    /// Builds a channel from a runtime identifier.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SpoError::InvalidConfig`] when the identifier is empty or
+    /// contains only whitespace.
+    pub fn try_new(id: impl Into<String>) -> SpoResult<Self> {
+        let id = id.into();
+        if id.trim().is_empty() {
+            return Err(SpoError::InvalidConfig(
+                "channel identifier must not be empty".into(),
+            ));
+        }
+        Ok(Self::new(id))
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::P => "P",
+            Self::I => "I",
+            Self::S => "S",
+            Self::Custom(id) => id,
+        }
+    }
+
+    #[must_use]
+    pub fn is_builtin(&self) -> bool {
+        matches!(self, Self::P | Self::I | Self::S)
+    }
+}
+
+impl Serialize for Channel {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for Channel {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let id = String::deserialize(deserializer)?;
+        Self::try_new(id).map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ChannelMetric {
+    pub channel: Channel,
+    pub r: f64,
+    pub psi: f64,
+    pub weight: f64,
+}
+
+impl ChannelMetric {
+    /// Builds and validates one channel-level coherence metric.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SpoError::InvalidConfig`] when `r` is non-finite or outside
+    /// `[0, 1]`, `psi` is non-finite, or `weight` is non-finite/negative.
+    pub fn new(channel: Channel, r: f64, psi: f64, weight: f64) -> SpoResult<Self> {
+        let metric = Self {
+            channel,
+            r,
+            psi,
+            weight,
+        };
+        metric.validate()?;
+        Ok(metric)
+    }
+
+    /// Validates finite ranges for one channel-level coherence metric.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SpoError::InvalidConfig`] when `r` is non-finite or outside
+    /// `[0, 1]`, `psi` is non-finite, or `weight` is non-finite/negative.
+    pub fn validate(&self) -> SpoResult<()> {
+        if !self.r.is_finite() || !(0.0..=1.0).contains(&self.r) {
+            return Err(SpoError::InvalidConfig(format!(
+                "channel {}: r must be finite and in [0, 1]",
+                self.channel.as_str()
+            )));
+        }
+        if !self.psi.is_finite() {
+            return Err(SpoError::InvalidConfig(format!(
+                "channel {}: psi must be finite",
+                self.channel.as_str()
+            )));
+        }
+        if !self.weight.is_finite() || self.weight < 0.0 {
+            return Err(SpoError::InvalidConfig(format!(
+                "channel {}: weight must be finite and non-negative",
+                self.channel.as_str()
+            )));
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -36,6 +157,8 @@ pub struct LayerState {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct UPDEState {
     pub layers: Vec<LayerState>,
+    #[serde(default)]
+    pub channel_metrics: Vec<ChannelMetric>,
     pub cross_layer_alignment: Vec<f64>,
     pub stability_proxy: f64,
     pub regime: Regime,
@@ -50,6 +173,45 @@ impl UPDEState {
         let sum: f64 = self.layers.iter().map(|l| l.r).sum();
         sum / self.layers.len() as f64
     }
+
+    #[must_use]
+    pub fn channel_metric(&self, channel: &Channel) -> Option<&ChannelMetric> {
+        self.channel_metrics
+            .iter()
+            .find(|metric| &metric.channel == channel)
+    }
+
+    #[must_use]
+    pub fn mean_channel_r(&self, channels: &[Channel]) -> f64 {
+        let vals: Vec<f64> = channels
+            .iter()
+            .filter_map(|channel| self.channel_metric(channel).map(|metric| metric.r))
+            .collect();
+        if vals.is_empty() {
+            return 0.0;
+        }
+        vals.iter().sum::<f64>() / vals.len() as f64
+    }
+
+    /// Validates all channel-level metrics in the state.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SpoError::InvalidConfig`] when any metric has invalid numeric
+    /// ranges or when multiple metrics use the same channel identifier.
+    pub fn validate_channel_metrics(&self) -> SpoResult<()> {
+        let mut seen = HashSet::new();
+        for metric in &self.channel_metrics {
+            metric.validate()?;
+            if !seen.insert(metric.channel.clone()) {
+                return Err(SpoError::InvalidConfig(format!(
+                    "duplicate channel metric for {}",
+                    metric.channel.as_str()
+                )));
+            }
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -58,9 +220,33 @@ mod tests {
 
     #[test]
     fn channel_serde() {
-        let json = serde_json::to_string(&Channel::S).unwrap();
-        let c: Channel = serde_json::from_str(&json).unwrap();
+        let json = serde_json::to_string(&Channel::S).expect("serialise channel");
+        let c: Channel = serde_json::from_str(&json).expect("deserialise channel");
         assert_eq!(c, Channel::S);
+    }
+
+    #[test]
+    fn custom_channel_serde() {
+        let channel = Channel::new("Risk");
+        assert_eq!(channel.as_str(), "Risk");
+        assert!(!channel.is_builtin());
+        let json = serde_json::to_string(&channel).expect("serialise custom channel");
+        assert_eq!(json, "\"Risk\"");
+        let c: Channel = serde_json::from_str(&json).expect("deserialise custom channel");
+        assert_eq!(c, Channel::Custom("Risk".into()));
+    }
+
+    #[test]
+    fn empty_custom_channel_rejected() {
+        let err = serde_json::from_str::<Channel>("\" \"")
+            .expect_err("empty channel identifier must be rejected");
+        assert!(err.to_string().contains("must not be empty"));
+    }
+
+    #[test]
+    fn try_new_rejects_empty_channel() {
+        let err = Channel::try_new("\t").expect_err("empty channel identifier must be rejected");
+        assert!(err.to_string().contains("must not be empty"));
     }
 
     #[test]
@@ -78,11 +264,47 @@ mod tests {
     }
 
     #[test]
+    fn phase_state_accepts_custom_channel() {
+        let ps = PhaseState {
+            theta: 1.0,
+            omega: 2.0,
+            amplitude: 0.5,
+            quality: 0.9,
+            channel: Channel::new("Mission"),
+            node_id: "n0".into(),
+        };
+        let json = serde_json::to_string(&ps).expect("serialise phase state");
+        assert!(json.contains("\"channel\":\"Mission\""));
+        let roundtrip: PhaseState = serde_json::from_str(&json).expect("deserialise phase state");
+        assert_eq!(roundtrip.channel.as_str(), "Mission");
+    }
+
+    #[test]
     fn layer_state_serde() {
         let ls = LayerState { r: 0.8, psi: 1.5 };
-        let json = serde_json::to_string(&ls).unwrap();
-        let ls2: LayerState = serde_json::from_str(&json).unwrap();
+        let json = serde_json::to_string(&ls).expect("serialise layer state");
+        let ls2: LayerState = serde_json::from_str(&json).expect("deserialise layer state");
         assert!((ls2.r - 0.8).abs() < 1e-12);
+    }
+
+    #[test]
+    fn channel_metric_validates_ranges() {
+        let metric =
+            ChannelMetric::new(Channel::new("Risk"), 0.7, 1.5, 0.25).expect("valid channel metric");
+        assert_eq!(metric.channel.as_str(), "Risk");
+        assert!((metric.r - 0.7).abs() < 1e-12);
+
+        let err = ChannelMetric::new(Channel::I, 1.1, 0.0, 1.0)
+            .expect_err("r outside [0, 1] must be rejected");
+        assert!(err.to_string().contains("r must be finite"));
+
+        let err = ChannelMetric::new(Channel::S, 0.5, f64::NAN, 1.0)
+            .expect_err("non-finite psi must be rejected");
+        assert!(err.to_string().contains("psi must be finite"));
+
+        let err = ChannelMetric::new(Channel::P, 0.5, 0.0, -0.1)
+            .expect_err("negative weight must be rejected");
+        assert!(err.to_string().contains("weight must be finite"));
     }
 
     #[test]
@@ -92,6 +314,7 @@ mod tests {
                 LayerState { r: 0.4, psi: 0.0 },
                 LayerState { r: 0.8, psi: 0.0 },
             ],
+            channel_metrics: vec![],
             cross_layer_alignment: vec![],
             stability_proxy: 0.5,
             regime: Regime::Nominal,
@@ -103,10 +326,78 @@ mod tests {
     fn upde_state_mean_r_empty() {
         let state = UPDEState {
             layers: vec![],
+            channel_metrics: vec![],
             cross_layer_alignment: vec![],
             stability_proxy: 0.0,
             regime: Regime::Nominal,
         };
         assert_eq!(state.mean_r(), 0.0);
+    }
+
+    #[test]
+    fn upde_state_channel_metrics_are_n_channel() {
+        let state = UPDEState {
+            layers: vec![],
+            channel_metrics: vec![
+                ChannelMetric::new(Channel::P, 0.8, 0.0, 1.0).expect("valid P metric"),
+                ChannelMetric::new(Channel::new("Risk"), 0.2, 1.0, 0.5)
+                    .expect("valid custom metric"),
+                ChannelMetric::new(Channel::new("Mission"), 0.6, 2.0, 0.25)
+                    .expect("valid custom metric"),
+            ],
+            cross_layer_alignment: vec![],
+            stability_proxy: 0.0,
+            regime: Regime::Nominal,
+        };
+
+        assert!(state.validate_channel_metrics().is_ok());
+        assert_eq!(
+            state
+                .channel_metric(&Channel::new("Risk"))
+                .expect("Risk metric")
+                .channel
+                .as_str(),
+            "Risk"
+        );
+        assert!(
+            (state.mean_channel_r(&[Channel::new("Risk"), Channel::new("Mission")]) - 0.4).abs()
+                < 1e-12
+        );
+    }
+
+    #[test]
+    fn upde_state_rejects_duplicate_channel_metrics() {
+        let state = UPDEState {
+            layers: vec![],
+            channel_metrics: vec![
+                ChannelMetric::new(Channel::new("Risk"), 0.2, 1.0, 0.5)
+                    .expect("valid custom metric"),
+                ChannelMetric::new(Channel::new("Risk"), 0.3, 2.0, 0.25)
+                    .expect("valid custom metric"),
+            ],
+            cross_layer_alignment: vec![],
+            stability_proxy: 0.0,
+            regime: Regime::Nominal,
+        };
+
+        let err = state
+            .validate_channel_metrics()
+            .expect_err("duplicate channel metrics must be rejected");
+        assert!(err.to_string().contains("duplicate channel metric"));
+    }
+
+    #[test]
+    fn upde_state_deserialises_legacy_json_without_channel_metrics() {
+        let json = r#"{
+            "layers": [{"r": 0.5, "psi": 0.0}],
+            "cross_layer_alignment": [],
+            "stability_proxy": 0.5,
+            "regime": "Nominal"
+        }"#;
+
+        let state: UPDEState = serde_json::from_str(json).expect("deserialise legacy UPDE state");
+
+        assert!(state.channel_metrics.is_empty());
+        assert_eq!(state.mean_r(), 0.5);
     }
 }

--- a/src/scpn_phase_orchestrator/binding/validator.py
+++ b/src/scpn_phase_orchestrator/binding/validator.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import math
 
 from scpn_phase_orchestrator.binding.types import (
+    STANDARD_CHANNELS,
     VALID_EXTRACTORS,
     VALID_KNOBS,
     VALID_SAFETY_TIERS,
@@ -69,6 +70,16 @@ def validate_binding_spec(spec: BindingSpec) -> list[str]:
     }
     family_driver_channels.update(spec.drivers.all_channel_configs())
     declared_or_used = family_driver_channels | set(spec.channels)
+    undeclared_named_channels = sorted(
+        channel
+        for channel in family_driver_channels
+        if channel not in STANDARD_CHANNELS and channel not in spec.channels
+    )
+    for channel in undeclared_named_channels:
+        errors.append(
+            f"channel {channel!r}: named N-channel drivers/families must be "
+            "declared under channels"
+        )
 
     for channel_name, channel_spec in spec.channels.items():
         if channel_spec.replay_semantics not in _VALID_REPLAY_SEMANTICS:
@@ -91,6 +102,29 @@ def validate_binding_spec(spec: BindingSpec) -> list[str]:
             errors.append(
                 f"channel {channel_name!r}: derive_rule is required when "
                 "derived_from is set"
+            )
+        if channel_spec.derived_from and channel_spec.replay_semantics != "derived":
+            errors.append(
+                f"channel {channel_name!r}: derived_from channels must use "
+                "replay_semantics='derived'"
+            )
+        if channel_spec.replay_semantics == "derived" and not channel_spec.derived_from:
+            errors.append(
+                f"channel {channel_name!r}: replay_semantics='derived' requires "
+                "derived_from"
+            )
+        if channel_spec.derive_rule and not channel_spec.derived_from:
+            errors.append(
+                f"channel {channel_name!r}: derive_rule requires derived_from"
+            )
+        if (
+            channel_spec.required
+            and not channel_spec.derived_from
+            and channel_name not in family_driver_channels
+        ):
+            errors.append(
+                f"channel {channel_name!r}: required channel must be backed by "
+                "an oscillator family or driver"
             )
 
     for group_name, group in spec.channel_groups.items():

--- a/src/scpn_phase_orchestrator/cli.py
+++ b/src/scpn_phase_orchestrator/cli.py
@@ -24,6 +24,7 @@ from scpn_phase_orchestrator.binding import (
     resolved_binding_config,
     validate_binding_spec,
 )
+from scpn_phase_orchestrator.binding.types import ProtocolNetSpec
 from scpn_phase_orchestrator.coupling.geometry_constraints import (
     GeometryConstraint,
     NonNegativeConstraint,
@@ -38,6 +39,10 @@ from scpn_phase_orchestrator.imprint.state import ImprintState
 from scpn_phase_orchestrator.imprint.update import ImprintModel
 from scpn_phase_orchestrator.monitor.boundaries import BoundaryObserver
 from scpn_phase_orchestrator.supervisor.events import EventBus
+from scpn_phase_orchestrator.supervisor.formal_export import (
+    export_petri_net_prism,
+    export_policy_rules_prism,
+)
 from scpn_phase_orchestrator.supervisor.petri_adapter import PetriNetAdapter
 from scpn_phase_orchestrator.supervisor.petri_net import (
     Arc,
@@ -48,6 +53,10 @@ from scpn_phase_orchestrator.supervisor.petri_net import (
     parse_guard,
 )
 from scpn_phase_orchestrator.supervisor.policy import SupervisorPolicy
+from scpn_phase_orchestrator.supervisor.policy_diagnostics import (
+    PolicyDryRunReport,
+    dry_run_policy_rules,
+)
 from scpn_phase_orchestrator.supervisor.policy_rules import (
     PolicyEngine,
     load_policy_rules,
@@ -103,6 +112,198 @@ def inspect_binding(binding_spec: str, json_out: bool) -> None:
 
     for line in format_resolved_binding_config(summary):
         click.echo(line)
+
+
+def _petri_net_from_protocol(protocol: ProtocolNetSpec) -> tuple[PetriNet, Marking]:
+    places = [Place(name) for name in protocol.places]
+    transitions = []
+    for ts in protocol.transitions:
+        guard = parse_guard(ts.guard) if ts.guard else None
+        transitions.append(
+            Transition(
+                name=ts.name,
+                inputs=[Arc(a["place"], a.get("weight", 1)) for a in ts.inputs],
+                outputs=[Arc(a["place"], a.get("weight", 1)) for a in ts.outputs],
+                guard=guard,
+            )
+        )
+    return PetriNet(places, transitions), Marking(tokens=dict(protocol.initial))
+
+
+@main.command("formal-export")
+@click.argument("binding_spec", type=click.Path(exists=True))
+@click.option(
+    "--output",
+    "-o",
+    default=None,
+    type=click.Path(),
+    help="Write PRISM model to a file instead of stdout",
+)
+@click.option("--module-name", default="spo_petri", help="PRISM module name")
+@click.option("--max-tokens", default=None, type=int, help="Token upper bound")
+@click.option(
+    "--export",
+    "export_target",
+    type=click.Choice(["protocol", "policy"]),
+    default="protocol",
+    show_default=True,
+    help="Supervisor artefact to export",
+)
+@click.option(
+    "--policy",
+    "policy_path",
+    default=None,
+    type=click.Path(exists=True),
+    help="Policy YAML path for --export policy; defaults to sibling policy.yaml",
+)
+def formal_export(
+    binding_spec: str,
+    output: str | None,
+    module_name: str,
+    max_tokens: int | None,
+    export_target: str,
+    policy_path: str | None,
+) -> None:
+    """Export supervisor artefacts for formal model checking."""
+    spec_path = Path(binding_spec)
+    spec = load_binding_spec(spec_path)
+    errors = validate_binding_spec(spec)
+    if errors:
+        for e in errors:
+            click.echo(f"ERROR: {e}", err=True)
+        raise SystemExit(1)
+
+    if export_target == "policy":
+        policy_file = (
+            Path(policy_path)
+            if policy_path is not None
+            else spec_path.parent / "policy.yaml"
+        )
+        if not policy_file.exists():
+            click.echo(f"ERROR: policy file not found: {policy_file}", err=True)
+            raise SystemExit(1)
+        rules = load_policy_rules(policy_file)
+        if not rules:
+            click.echo("ERROR: policy file contains no rules", err=True)
+            raise SystemExit(1)
+        export = export_policy_rules_prism(rules, module_name=module_name)
+        if output is None:
+            click.echo(export.model, nl=False)
+            return
+        Path(output).write_text(export.model, encoding="utf-8")
+        click.echo(f"PRISM model written: {output}")
+        return
+
+    if spec.protocol_net is None:
+        click.echo("ERROR: binding spec has no protocol_net", err=True)
+        raise SystemExit(1)
+
+    net, marking = _petri_net_from_protocol(spec.protocol_net)
+    export = export_petri_net_prism(
+        net,
+        marking,
+        module_name=module_name,
+        max_tokens=max_tokens,
+    )
+    if output is None:
+        click.echo(export.model, nl=False)
+        return
+    Path(output).write_text(export.model, encoding="utf-8")
+    click.echo(f"PRISM model written: {output}")
+
+
+def _policy_report_dict(report: PolicyDryRunReport) -> dict[str, object]:
+    return {
+        "steps": report.steps,
+        "rules": list(report.rules),
+        "fire_counts": report.fire_counts,
+        "action_counts": report.action_counts,
+        "unreachable_rules": list(report.unreachable_rules),
+        "overlapping_steps": list(report.overlapping_steps),
+        "action_collision_steps": list(report.action_collision_steps),
+        "step_reports": [
+            {
+                "step": step.step,
+                "regime": step.regime,
+                "fired_rules": list(step.fired_rules),
+                "actions": list(step.actions),
+            }
+            for step in report.step_reports
+        ],
+    }
+
+
+@main.command("policy-dry-run")
+@click.argument("binding_spec", type=click.Path(exists=True))
+@click.argument("audit_log", type=click.Path(exists=True))
+@click.option(
+    "--policy",
+    "policy_path",
+    default=None,
+    type=click.Path(exists=True),
+    help="Policy YAML path; defaults to binding spec sibling policy.yaml",
+)
+@click.option("--json-out", is_flag=True, help="Output JSON instead of text")
+def policy_dry_run(
+    binding_spec: str,
+    audit_log: str,
+    policy_path: str | None,
+    json_out: bool,
+) -> None:
+    """Replay policy rules against an audit log without applying actuation."""
+    spec_path = Path(binding_spec)
+    spec = load_binding_spec(spec_path)
+    errors = validate_binding_spec(spec)
+    if errors:
+        for e in errors:
+            click.echo(f"ERROR: {e}", err=True)
+        raise SystemExit(1)
+
+    policy_file = (
+        Path(policy_path)
+        if policy_path is not None
+        else spec_path.parent / "policy.yaml"
+    )
+    if not policy_file.exists():
+        click.echo(f"ERROR: policy file not found: {policy_file}", err=True)
+        raise SystemExit(1)
+    rules = load_policy_rules(policy_file)
+    if not rules:
+        click.echo("ERROR: policy file contains no rules", err=True)
+        raise SystemExit(1)
+
+    entries = ReplayEngine(audit_log).load()
+    report = dry_run_policy_rules(
+        rules,
+        entries,
+        good_layers=list(spec.objectives.good_layers),
+        bad_layers=list(spec.objectives.bad_layers),
+    )
+    if json_out:
+        click.echo(json.dumps(_policy_report_dict(report), indent=2, sort_keys=True))
+        return
+
+    click.echo(f"Steps: {report.steps}  Rules: {len(report.rules)}")
+    click.echo("Rule fires:")
+    for rule in report.rules:
+        click.echo(f"  {rule}: {report.fire_counts.get(rule, 0)}")
+    if report.unreachable_rules:
+        click.echo()
+        click.echo("Unreachable rules:")
+        for rule in report.unreachable_rules:
+            click.echo(f"  {rule}")
+    if report.overlapping_steps:
+        click.echo()
+        click.echo(
+            "Overlapping rule steps: "
+            + ", ".join(str(step) for step in report.overlapping_steps)
+        )
+    if report.action_collision_steps:
+        click.echo()
+        click.echo(
+            "Action collision steps: "
+            + ", ".join(str(step) for step in report.action_collision_steps)
+        )
 
 
 @main.command()
@@ -166,24 +367,11 @@ def run(binding_spec: str, steps: int, audit: str | None, seed: int) -> None:
 
     petri_adapter: PetriNetAdapter | None = None
     if spec.protocol_net is not None:
-        pn = spec.protocol_net
-        places = [Place(name) for name in pn.places]
-        transitions = []
-        for ts in pn.transitions:
-            guard = parse_guard(ts.guard) if ts.guard else None
-            transitions.append(
-                Transition(
-                    name=ts.name,
-                    inputs=[Arc(a["place"], a.get("weight", 1)) for a in ts.inputs],
-                    outputs=[Arc(a["place"], a.get("weight", 1)) for a in ts.outputs],
-                    guard=guard,
-                )
-            )
-        net = PetriNet(places, transitions)
+        net, marking = _petri_net_from_protocol(spec.protocol_net)
         petri_adapter = PetriNetAdapter(
             net,
-            Marking(tokens=dict(pn.initial)),
-            pn.place_regime,
+            marking,
+            spec.protocol_net.place_regime,
             event_bus=event_bus,
         )
 
@@ -568,7 +756,7 @@ def report(log_path: str, json_out: bool) -> None:
         raise SystemExit(1)
 
     n_steps = len(steps)
-    n_layers = len(steps[0]["layers"])
+    n_layers = max(len(s.get("layers", [])) for s in steps)
     r_series = [
         [s["layers"][i]["R"] for s in steps if i < len(s["layers"])]
         for i in range(n_layers)

--- a/src/scpn_phase_orchestrator/reporting/explainability.py
+++ b/src/scpn_phase_orchestrator/reporting/explainability.py
@@ -121,7 +121,7 @@ def _event_lines(entries: list[dict[str, Any]], limit: int = 12) -> tuple[str, .
 def _metric_summary(steps: list[dict[str, Any]]) -> tuple[str, ...]:
     if not steps:
         return ()
-    n_layers = len(steps[0].get("layers", []))
+    n_layers = max(len(step.get("layers", [])) for step in steps)
     lines: list[str] = []
     for idx in range(n_layers):
         series = [
@@ -208,7 +208,7 @@ def build_explainability_report(
     last = steps[-1]
     return ExplainabilityReport(
         steps=len(steps),
-        layers=len(steps[0].get("layers", [])),
+        layers=max(len(step.get("layers", [])) for step in steps),
         hash_chain_ok=integrity_ok,
         hash_chain_verified=n_verified,
         final_regime=str(last.get("regime", "unknown")),

--- a/src/scpn_phase_orchestrator/reporting/plots.py
+++ b/src/scpn_phase_orchestrator/reporting/plots.py
@@ -73,7 +73,7 @@ class CoherencePlot:
     def _extract_r_series(self) -> tuple[list[int], int, list[list[float]]]:
         steps = self._require_steps()
         x = [s["step"] for s in steps]
-        n_layers = len(steps[0]["layers"])
+        n_layers = max(len(s.get("layers", [])) for s in steps)
         series = []
         for i in range(n_layers):
             series.append(

--- a/src/scpn_phase_orchestrator/supervisor/__init__.py
+++ b/src/scpn_phase_orchestrator/supervisor/__init__.py
@@ -10,6 +10,11 @@ from __future__ import annotations
 
 from scpn_phase_orchestrator.actuation.mapper import ControlAction
 from scpn_phase_orchestrator.supervisor.events import EventBus, RegimeEvent
+from scpn_phase_orchestrator.supervisor.formal_export import (
+    PrismExport,
+    export_petri_net_prism,
+    export_policy_rules_prism,
+)
 from scpn_phase_orchestrator.supervisor.petri_adapter import PetriNetAdapter
 from scpn_phase_orchestrator.supervisor.petri_net import (
     Arc,
@@ -19,6 +24,11 @@ from scpn_phase_orchestrator.supervisor.petri_net import (
     Transition,
 )
 from scpn_phase_orchestrator.supervisor.policy import SupervisorPolicy
+from scpn_phase_orchestrator.supervisor.policy_diagnostics import (
+    PolicyDryRunReport,
+    PolicyDryRunStep,
+    dry_run_policy_rules,
+)
 from scpn_phase_orchestrator.supervisor.policy_rules import (
     CompoundCondition,
     PolicyAction,
@@ -43,9 +53,12 @@ __all__ = [
     "PetriNetAdapter",
     "Place",
     "PolicyAction",
+    "PolicyDryRunReport",
+    "PolicyDryRunStep",
     "PolicyCondition",
     "PolicyEngine",
     "PolicyRule",
+    "PrismExport",
     "Prediction",
     "PredictiveSupervisor",
     "Regime",
@@ -53,5 +66,8 @@ __all__ = [
     "RegimeManager",
     "SupervisorPolicy",
     "Transition",
+    "dry_run_policy_rules",
+    "export_petri_net_prism",
+    "export_policy_rules_prism",
     "load_policy_rules",
 ]

--- a/src/scpn_phase_orchestrator/supervisor/formal_export.py
+++ b/src/scpn_phase_orchestrator/supervisor/formal_export.py
@@ -1,0 +1,393 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Commercial license available
+# © Concepts 1996–2026 Miroslav Šotek. All rights reserved.
+# © Code 2020–2026 Miroslav Šotek. All rights reserved.
+# ORCID: 0009-0009-3560-0851
+# Contact: www.anulum.li | protoscience@anulum.li
+# SCPN Phase Orchestrator — Formal supervisor exporters
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from math import isfinite
+
+from scpn_phase_orchestrator.exceptions import PolicyError
+from scpn_phase_orchestrator.supervisor.petri_net import Marking, PetriNet, Transition
+from scpn_phase_orchestrator.supervisor.policy_rules import (
+    CompoundCondition,
+    PolicyCondition,
+    PolicyRule,
+)
+
+__all__ = ["PrismExport", "export_petri_net_prism", "export_policy_rules_prism"]
+
+_IDENT_RE = re.compile(r"[^A-Za-z0-9_]")
+
+
+@dataclass(frozen=True)
+class PrismExport:
+    """PRISM model text plus the identifier mapping used during export."""
+
+    model: str
+    place_names: dict[str, str]
+    metric_names: dict[str, str]
+    transition_names: dict[str, str]
+    rule_names: dict[str, str] = field(default_factory=dict)
+    action_names: dict[str, str] = field(default_factory=dict)
+
+
+def _identifier(raw: str, *, prefix: str) -> str:
+    cleaned = _IDENT_RE.sub("_", raw).strip("_")
+    if not cleaned:
+        cleaned = prefix
+    if cleaned[0].isdigit():
+        cleaned = f"{prefix}_{cleaned}"
+    return cleaned
+
+
+def _unique_identifier(
+    raw: str,
+    *,
+    prefix: str,
+    used: set[str],
+) -> str:
+    base = _identifier(raw, prefix=prefix)
+    candidate = base
+    suffix = 2
+    while candidate in used:
+        candidate = f"{base}_{suffix}"
+        suffix += 1
+    used.add(candidate)
+    return candidate
+
+
+def _place_mapping(net: PetriNet) -> dict[str, str]:
+    used: set[str] = set()
+    return {
+        name: _unique_identifier(name, prefix="p", used=used)
+        for name in sorted(net.place_names)
+    }
+
+
+def _transition_mapping(net: PetriNet) -> dict[str, str]:
+    used: set[str] = set()
+    return {
+        transition.name: _unique_identifier(transition.name, prefix="t", used=used)
+        for transition in net.transitions
+    }
+
+
+def _metric_mapping(net: PetriNet) -> dict[str, str]:
+    used: set[str] = set()
+    metrics = sorted(
+        {
+            transition.guard.metric
+            for transition in net.transitions
+            if transition.guard is not None
+        }
+    )
+    return {
+        metric: _unique_identifier(metric, prefix="m", used=used) for metric in metrics
+    }
+
+
+def _policy_metric_key(condition: PolicyCondition) -> str:
+    if condition.layer is None:
+        return condition.metric
+    return f"{condition.metric}.{condition.layer}"
+
+
+def _policy_conditions(
+    condition: PolicyCondition | CompoundCondition,
+) -> list[PolicyCondition]:
+    if isinstance(condition, CompoundCondition):
+        return list(condition.conditions)
+    return [condition]
+
+
+def _policy_metric_mapping(rules: list[PolicyRule]) -> dict[str, str]:
+    used: set[str] = set()
+    metrics = sorted(
+        {
+            _policy_metric_key(condition)
+            for rule in rules
+            for condition in _policy_conditions(rule.condition)
+        }
+    )
+    return {
+        metric: _unique_identifier(metric, prefix="m", used=used) for metric in metrics
+    }
+
+
+def _rule_mapping(rules: list[PolicyRule]) -> dict[str, str]:
+    used: set[str] = set()
+    return {
+        rule.name: _unique_identifier(rule.name, prefix="rule", used=used)
+        for rule in rules
+    }
+
+
+def _action_key(rule: PolicyRule, action_index: int) -> str:
+    action = rule.actions[action_index]
+    return f"{rule.name}.{action.knob}.{action.scope}.{action_index}"
+
+
+def _action_mapping(rules: list[PolicyRule]) -> dict[str, str]:
+    used: set[str] = set()
+    return {
+        _action_key(rule, i): _unique_identifier(
+            f"{rule.name}_{action.knob}_{action.scope}_{i}",
+            prefix="action",
+            used=used,
+        )
+        for rule in rules
+        for i, action in enumerate(rule.actions)
+    }
+
+
+def _regime_mapping(rules: list[PolicyRule]) -> dict[str, int]:
+    regimes = sorted({regime.upper() for rule in rules for regime in rule.regimes})
+    return {regime: idx for idx, regime in enumerate(regimes)}
+
+
+def _guard_expr(transition: Transition, metric_names: dict[str, str]) -> str:
+    if transition.guard is None:
+        return "true"
+    guard = transition.guard
+    return f"{metric_names[guard.metric]} {guard.op} {guard.threshold:.17g}"
+
+
+def _policy_condition_expr(
+    condition: PolicyCondition,
+    metric_names: dict[str, str],
+) -> str:
+    metric = metric_names[_policy_metric_key(condition)]
+    return f"{metric} {condition.op} {condition.threshold:.17g}"
+
+
+def _policy_guard_expr(
+    condition: PolicyCondition | CompoundCondition,
+    metric_names: dict[str, str],
+) -> str:
+    if isinstance(condition, CompoundCondition):
+        if not condition.conditions:
+            raise PolicyError("compound policy condition must not be empty")
+        op = "|" if condition.logic.upper() == "OR" else "&"
+        parts = [
+            _policy_condition_expr(item, metric_names) for item in condition.conditions
+        ]
+        return "(" + f" {op} ".join(parts) + ")"
+    return _policy_condition_expr(condition, metric_names)
+
+
+def _regime_guard_expr(rule: PolicyRule, regime_names: dict[str, int]) -> str:
+    regimes = [regime.upper() for regime in rule.regimes]
+    if not regimes:
+        raise PolicyError(f"policy rule {rule.name!r} has no regimes")
+    parts = [f"regime = {regime_names[regime]}" for regime in regimes]
+    return "(" + " | ".join(parts) + ")"
+
+
+def _input_expr(transition: Transition, place_names: dict[str, str]) -> str:
+    if not transition.inputs:
+        return "true"
+    return " & ".join(
+        f"{place_names[arc.place]} >= {arc.weight}" for arc in transition.inputs
+    )
+
+
+def _update_expr(transition: Transition, place_names: dict[str, str]) -> str:
+    deltas = dict.fromkeys(place_names, 0)
+    for arc in transition.inputs:
+        deltas[arc.place] -= arc.weight
+    for arc in transition.outputs:
+        deltas[arc.place] += arc.weight
+    updates = []
+    for place, identifier in place_names.items():
+        delta = deltas[place]
+        if delta == 0:
+            updates.append(f"({identifier}'={identifier})")
+        elif delta > 0:
+            updates.append(f"({identifier}'={identifier}+{delta})")
+        else:
+            updates.append(f"({identifier}'={identifier}-{abs(delta)})")
+    return " & ".join(updates)
+
+
+def _token_upper_bound(
+    net: PetriNet,
+    initial_marking: Marking,
+    *,
+    minimum: int,
+) -> int:
+    observed = [minimum, *initial_marking.tokens.values()]
+    for transition in net.transitions:
+        observed.extend(arc.weight for arc in transition.inputs)
+        observed.extend(arc.weight for arc in transition.outputs)
+    return max(observed)
+
+
+def _policy_fire_bound(rule: PolicyRule) -> int:
+    return max(1, rule.max_fires)
+
+
+def export_petri_net_prism(
+    net: PetriNet,
+    initial_marking: Marking,
+    *,
+    module_name: str = "spo_petri",
+    max_tokens: int | None = None,
+) -> PrismExport:
+    """Serialise a Petri net into a bounded PRISM MDP model.
+
+    Guard metrics become PRISM constants, so safety properties can be checked
+    over scenario-specific metric assignments without changing the net model.
+    """
+
+    if not net.place_names:
+        raise PolicyError("cannot export Petri net without places")
+    if max_tokens is not None and max_tokens < 1:
+        raise PolicyError("max_tokens must be >= 1")
+
+    place_names = _place_mapping(net)
+    transition_names = _transition_mapping(net)
+    metric_names = _metric_mapping(net)
+    token_bound = max_tokens or _token_upper_bound(net, initial_marking, minimum=1)
+    module_identifier = _identifier(module_name, prefix="module")
+
+    lines = [
+        "mdp",
+        "",
+        "// Generated from SCPN PetriNet for PRISM model checking.",
+    ]
+    if any(raw != mapped for raw, mapped in place_names.items()):
+        lines.append("// Place identifiers:")
+        lines.extend(f"//   {raw} -> {mapped}" for raw, mapped in place_names.items())
+    if metric_names:
+        lines.append("// Guard metric constants:")
+        lines.extend(f"//   {raw} -> {mapped}" for raw, mapped in metric_names.items())
+        lines.extend(f"const double {mapped};" for mapped in metric_names.values())
+    lines.extend(["", f"module {module_identifier}"])
+
+    for raw_name, identifier in place_names.items():
+        initial = initial_marking[raw_name]
+        if initial > token_bound:
+            raise PolicyError(
+                f"initial marking for {raw_name!r} exceeds max_tokens={token_bound}"
+            )
+        lines.append(f"  {identifier} : [0..{token_bound}] init {initial};")
+
+    lines.append("")
+    for transition in net.transitions:
+        guard = _guard_expr(transition, metric_names)
+        inputs = _input_expr(transition, place_names)
+        command_guard = f"{guard} & {inputs}"
+        update = _update_expr(transition, place_names)
+        action = transition_names[transition.name]
+        lines.append(f"  [{action}] {command_guard} -> {update};")
+
+    lines.extend(["endmodule", ""])
+    for raw_name, identifier in place_names.items():
+        lines.append(f'label "active_{identifier}" = {identifier} > 0;')
+        if raw_name != identifier:
+            lines.append(f"// active_{identifier} maps original place {raw_name!r}")
+
+    return PrismExport(
+        model="\n".join(lines) + "\n",
+        place_names=place_names,
+        metric_names=metric_names,
+        transition_names=transition_names,
+    )
+
+
+def export_policy_rules_prism(
+    rules: list[PolicyRule],
+    *,
+    module_name: str = "spo_policy",
+) -> PrismExport:
+    """Serialise policy rules into a bounded PRISM MDP model.
+
+    Metrics and current regime are model inputs represented as PRISM
+    constants. Each rule has a bounded fire counter; unlimited rules are
+    represented as one-shot reachability counters for model-checking queries.
+    """
+
+    if not rules:
+        raise PolicyError("cannot export policy rules without rules")
+
+    for rule in rules:
+        if not rule.name:
+            raise PolicyError("policy rule names must not be empty")
+        if not rule.regimes:
+            raise PolicyError(f"policy rule {rule.name!r} has no regimes")
+        if not rule.actions:
+            raise PolicyError(f"policy rule {rule.name!r} has no actions")
+        for condition in _policy_conditions(rule.condition):
+            if not condition.metric:
+                raise PolicyError(f"policy rule {rule.name!r} has an empty metric")
+            if not isfinite(condition.threshold):
+                raise PolicyError(f"policy rule {rule.name!r} has non-finite threshold")
+            if condition.op not in {">", ">=", "<", "<=", "=="}:
+                raise PolicyError(
+                    f"policy rule {rule.name!r} has unsupported operator "
+                    f"{condition.op!r}"
+                )
+
+    metric_names = _policy_metric_mapping(rules)
+    rule_names = _rule_mapping(rules)
+    action_names = _action_mapping(rules)
+    regime_names = _regime_mapping(rules)
+    module_identifier = _identifier(module_name, prefix="module")
+
+    lines = [
+        "mdp",
+        "",
+        "// Generated from SCPN PolicyEngine rules for PRISM model checking.",
+        "// Regime constants:",
+    ]
+    lines.extend(f"//   {name} -> {value}" for name, value in regime_names.items())
+    lines.append(f"const int regime; // 0..{max(regime_names.values())}")
+    if metric_names:
+        lines.append("// Policy metric constants:")
+        lines.extend(f"//   {raw} -> {mapped}" for raw, mapped in metric_names.items())
+        lines.extend(f"const double {mapped};" for mapped in metric_names.values())
+    lines.extend(["", f"module {module_identifier}"])
+
+    for rule in rules:
+        rule_id = rule_names[rule.name]
+        lines.append(f"  {rule_id}_fires : [0..{_policy_fire_bound(rule)}] init 0;")
+
+    lines.append("")
+    for rule in rules:
+        rule_id = rule_names[rule.name]
+        guard = " & ".join(
+            [
+                _regime_guard_expr(rule, regime_names),
+                _policy_guard_expr(rule.condition, metric_names),
+                f"{rule_id}_fires < {_policy_fire_bound(rule)}",
+            ]
+        )
+        lines.append(f"  [{rule_id}] {guard} -> ({rule_id}_fires'={rule_id}_fires+1);")
+
+    lines.extend(["endmodule", ""])
+    for rule in rules:
+        rule_id = rule_names[rule.name]
+        lines.append(f'label "fires_{rule_id}" = {rule_id}_fires > 0;')
+        for i, action in enumerate(rule.actions):
+            action_id = action_names[_action_key(rule, i)]
+            lines.append(f'label "emits_{action_id}" = {rule_id}_fires > 0;')
+            lines.append(
+                f"//   {action_id}: knob={action.knob!r}, "
+                f"scope={action.scope!r}, value={action.value:.17g}, "
+                f"ttl_s={action.ttl_s:.17g}"
+            )
+
+    return PrismExport(
+        model="\n".join(lines) + "\n",
+        place_names={},
+        metric_names=metric_names,
+        transition_names={},
+        rule_names=rule_names,
+        action_names=action_names,
+    )

--- a/src/scpn_phase_orchestrator/supervisor/policy_diagnostics.py
+++ b/src/scpn_phase_orchestrator/supervisor/policy_diagnostics.py
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Commercial license available
+# © Concepts 1996–2026 Miroslav Šotek. All rights reserved.
+# © Code 2020–2026 Miroslav Šotek. All rights reserved.
+# ORCID: 0009-0009-3560-0851
+# Contact: www.anulum.li | protoscience@anulum.li
+# SCPN Phase Orchestrator — Policy rule dry-run diagnostics
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from scpn_phase_orchestrator.supervisor.policy_rules import (
+    PolicyEngine,
+    PolicyRule,
+)
+from scpn_phase_orchestrator.supervisor.regimes import Regime
+from scpn_phase_orchestrator.upde.metrics import LayerState, UPDEState
+
+__all__ = [
+    "PolicyDryRunReport",
+    "PolicyDryRunStep",
+    "dry_run_policy_rules",
+]
+
+
+@dataclass(frozen=True)
+class PolicyDryRunStep:
+    """One audit step and the policy rules that fired on it."""
+
+    step: int
+    regime: str
+    fired_rules: tuple[str, ...]
+    actions: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class PolicyDryRunReport:
+    """Summary of replayed policy behaviour over an audit log."""
+
+    steps: int
+    rules: tuple[str, ...]
+    fire_counts: dict[str, int]
+    action_counts: dict[str, int]
+    unreachable_rules: tuple[str, ...]
+    overlapping_steps: tuple[int, ...]
+    action_collision_steps: tuple[int, ...]
+    step_reports: tuple[PolicyDryRunStep, ...]
+
+
+def _regime_from_entry(entry: dict[str, Any]) -> Regime:
+    raw = str(entry.get("regime", "nominal")).lower()
+    for regime in Regime:
+        if regime.value == raw or regime.name.lower() == raw:
+            return regime
+    return Regime.NOMINAL
+
+
+def _state_from_entry(entry: dict[str, Any]) -> UPDEState:
+    raw_layers = entry.get("layers", [])
+    layers = []
+    for raw_layer in raw_layers:
+        layer = raw_layer if isinstance(raw_layer, dict) else {}
+        layers.append(
+            LayerState(
+                R=float(layer.get("R", 0.0)),
+                psi=float(layer.get("psi", 0.0)),
+                mean_amplitude=float(layer.get("mean_amplitude", 0.0)),
+                amplitude_spread=float(layer.get("amplitude_spread", 0.0)),
+            )
+        )
+    return UPDEState(
+        layers=layers,
+        cross_layer_alignment=np.zeros((len(layers), len(layers))),
+        stability_proxy=float(entry.get("stability", 0.0)),
+        regime_id=str(entry.get("regime", "nominal")),
+        mean_amplitude=float(entry.get("mean_amplitude", 0.0)),
+        pac_max=float(entry.get("pac_max", 0.0)),
+        subcritical_fraction=float(entry.get("subcritical_fraction", 0.0)),
+        boundary_violation_count=int(entry.get("boundary_violation_count", 0)),
+        imprint_mean=float(entry.get("imprint_mean", 0.0)),
+    )
+
+
+def _rule_name_from_justification(justification: str) -> str:
+    prefix = "policy rule: "
+    if justification.startswith(prefix):
+        return justification[len(prefix) :]
+    return justification or "<unknown>"
+
+
+def _step_entries(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [entry for entry in entries if "step" in entry and "layers" in entry]
+
+
+def dry_run_policy_rules(
+    rules: list[PolicyRule],
+    entries: list[dict[str, Any]],
+    *,
+    good_layers: list[int],
+    bad_layers: list[int],
+) -> PolicyDryRunReport:
+    """Replay policy rules over audit steps without applying actuation."""
+
+    engine = PolicyEngine(rules)
+    rule_names = tuple(rule.name for rule in rules)
+    fire_counts = dict.fromkeys(rule_names, 0)
+    action_counts: dict[str, int] = {}
+    step_reports: list[PolicyDryRunStep] = []
+    overlapping_steps: list[int] = []
+    action_collision_steps: list[int] = []
+
+    for entry in _step_entries(entries):
+        step_no = int(entry.get("step", 0))
+        regime = _regime_from_entry(entry)
+        state = _state_from_entry(entry)
+        actions = engine.evaluate(regime, state, good_layers, bad_layers)
+        fired_rules = tuple(
+            _rule_name_from_justification(action.justification) for action in actions
+        )
+        distinct_rules = tuple(dict.fromkeys(fired_rules))
+        if len(distinct_rules) > 1:
+            overlapping_steps.append(step_no)
+
+        action_keys = tuple(f"{action.knob}:{action.scope}" for action in actions)
+        if len(set(action_keys)) < len(action_keys):
+            action_collision_steps.append(step_no)
+        for rule_name in fired_rules:
+            fire_counts[rule_name] = fire_counts.get(rule_name, 0) + 1
+        for action_key in action_keys:
+            action_counts[action_key] = action_counts.get(action_key, 0) + 1
+
+        step_reports.append(
+            PolicyDryRunStep(
+                step=step_no,
+                regime=regime.value,
+                fired_rules=distinct_rules,
+                actions=action_keys,
+            )
+        )
+        engine.advance_clock(1.0)
+
+    unreachable = tuple(name for name in rule_names if fire_counts.get(name, 0) == 0)
+    return PolicyDryRunReport(
+        steps=len(step_reports),
+        rules=rule_names,
+        fire_counts=fire_counts,
+        action_counts=action_counts,
+        unreachable_rules=unreachable,
+        overlapping_steps=tuple(overlapping_steps),
+        action_collision_steps=tuple(action_collision_steps),
+        step_reports=tuple(step_reports),
+    )

--- a/tests/test_binding_validator.py
+++ b/tests/test_binding_validator.py
@@ -13,6 +13,7 @@ from dataclasses import replace
 from scpn_phase_orchestrator.binding.types import (
     ActuatorMapping,
     BoundaryDef,
+    ChannelSpec,
     OscillatorFamily,
 )
 from scpn_phase_orchestrator.binding.validator import validate_binding_spec
@@ -147,7 +148,16 @@ def test_valid_channels_accepted(sample_binding_spec):
         families = {
             "f": OscillatorFamily(channel=ch, extractor_type="hilbert", config={}),
         }
-        spec = replace(sample_binding_spec, oscillator_families=families)
+        channels = (
+            {}
+            if ch in {"P", "I", "S"}
+            else {ch: ChannelSpec(role="domain", units="phase")}
+        )
+        spec = replace(
+            sample_binding_spec,
+            oscillator_families=families,
+            channels=channels,
+        )
         errors = validate_binding_spec(spec)
         ch_errors = [e for e in errors if "channel" in e]
         assert ch_errors == [], f"channel={ch!r} should be valid, got: {ch_errors}"
@@ -190,6 +200,82 @@ def test_valid_version_formats(sample_binding_spec):
         errors = validate_binding_spec(spec)
         ver_errors = [e for e in errors if "version" in e]
         assert ver_errors == [], f"version={v!r} should be valid, got: {ver_errors}"
+
+
+def test_named_nchannel_must_be_declared(sample_binding_spec):
+    families = {
+        "risk": OscillatorFamily(channel="Risk", extractor_type="event", config={}),
+    }
+    bad = replace(sample_binding_spec, oscillator_families=families, channels={})
+
+    errors = validate_binding_spec(bad)
+
+    assert any("named N-channel" in e and "Risk" in e for e in errors)
+
+
+def test_required_channel_must_have_runtime_evidence(sample_binding_spec):
+    bad = replace(
+        sample_binding_spec,
+        channels={"Risk": ChannelSpec(role="risk", required=True)},
+    )
+
+    errors = validate_binding_spec(bad)
+
+    assert any("required channel" in e and "Risk" in e for e in errors)
+
+
+def test_derived_channel_requires_derived_replay_semantics(sample_binding_spec):
+    bad = replace(
+        sample_binding_spec,
+        channels={
+            "Risk": ChannelSpec(
+                role="risk",
+                required=False,
+                replay_semantics="phase",
+                derived_from=["P"],
+                derive_rule="risk = phase(P)",
+            )
+        },
+    )
+
+    errors = validate_binding_spec(bad)
+
+    assert any("replay_semantics='derived'" in e for e in errors)
+
+
+def test_derived_replay_semantics_requires_sources(sample_binding_spec):
+    bad = replace(
+        sample_binding_spec,
+        channels={
+            "Risk": ChannelSpec(
+                role="risk",
+                required=False,
+                replay_semantics="derived",
+            )
+        },
+    )
+
+    errors = validate_binding_spec(bad)
+
+    assert any("requires derived_from" in e for e in errors)
+
+
+def test_derive_rule_requires_sources(sample_binding_spec):
+    bad = replace(
+        sample_binding_spec,
+        channels={
+            "Risk": ChannelSpec(
+                role="risk",
+                required=False,
+                replay_semantics="phase",
+                derive_rule="risk = phase(P)",
+            )
+        },
+    )
+
+    errors = validate_binding_spec(bad)
+
+    assert any("derive_rule requires derived_from" in e for e in errors)
 
 
 # Pipeline wiring: binding validator tested via schema enforcement, required field

--- a/tests/test_end_to_end_pipeline.py
+++ b/tests/test_end_to_end_pipeline.py
@@ -256,7 +256,7 @@ class TestEndToEndChannels:
 class TestAllDomainpacksLoad:
     """Every domainpack loads without error."""
 
-    def test_all_25_load(self):
+    def test_all_domainpacks_load(self):
         loaded = 0
         for pack_dir in sorted(DOMAINPACK_DIR.iterdir()):
             if not pack_dir.is_dir():
@@ -269,4 +269,4 @@ class TestAllDomainpacksLoad:
             assert len(spec.layers) > 0
             assert len(spec.oscillator_families) > 0
             loaded += 1
-        assert loaded == 33
+        assert loaded == 36

--- a/tests/test_formal_export.py
+++ b/tests/test_formal_export.py
@@ -1,0 +1,333 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Commercial license available
+# © Concepts 1996–2026 Miroslav Šotek. All rights reserved.
+# © Code 2020–2026 Miroslav Šotek. All rights reserved.
+# ORCID: 0009-0009-3560-0851
+# Contact: www.anulum.li | protoscience@anulum.li
+# SCPN Phase Orchestrator — Formal exporter tests
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from scpn_phase_orchestrator.cli import main
+from scpn_phase_orchestrator.exceptions import PolicyError
+from scpn_phase_orchestrator.supervisor import (
+    CompoundCondition,
+    PolicyAction,
+    PolicyCondition,
+    PolicyRule,
+    export_petri_net_prism,
+    export_policy_rules_prism,
+)
+from scpn_phase_orchestrator.supervisor.formal_export import PrismExport
+from scpn_phase_orchestrator.supervisor.petri_net import (
+    Arc,
+    Guard,
+    Marking,
+    PetriNet,
+    Place,
+    Transition,
+)
+
+
+def _net() -> PetriNet:
+    return PetriNet(
+        [
+            Place("warmup"),
+            Place("nominal"),
+            Place("cool-down"),
+            Place("done"),
+        ],
+        [
+            Transition(
+                name="start",
+                inputs=[Arc("warmup")],
+                outputs=[Arc("nominal")],
+                guard=Guard("stability.proxy", ">", 0.6),
+            ),
+            Transition(
+                name="wind down",
+                inputs=[Arc("nominal", weight=2)],
+                outputs=[Arc("cool-down")],
+                guard=Guard("R_bad.0", "<=", 0.3),
+            ),
+            Transition(
+                name="finish",
+                inputs=[Arc("cool-down")],
+                outputs=[Arc("done")],
+            ),
+        ],
+    )
+
+
+def test_petri_net_prism_export_serialises_guards_and_arcs() -> None:
+    export = export_petri_net_prism(
+        _net(),
+        Marking(tokens={"warmup": 1, "nominal": 2}),
+        module_name="supervisor net",
+    )
+
+    assert isinstance(export, PrismExport)
+    assert export.metric_names == {
+        "R_bad.0": "R_bad_0",
+        "stability.proxy": "stability_proxy",
+    }
+    assert "mdp\n" in export.model
+    assert "module supervisor_net" in export.model
+    assert "const double R_bad_0;" in export.model
+    assert "const double stability_proxy;" in export.model
+    assert "warmup : [0..2] init 1;" in export.model
+    assert "nominal : [0..2] init 2;" in export.model
+    assert "[start] stability_proxy > 0.59999999999999998 & warmup >= 1" in (
+        export.model
+    )
+    assert "[wind_down] R_bad_0 <= 0.29999999999999999 & nominal >= 2" in (export.model)
+    assert "(nominal'=nominal-2)" in export.model
+    assert "(cool_down'=cool_down+1)" in export.model
+    assert 'label "active_done" = done > 0;' in export.model
+
+
+def test_petri_net_prism_export_is_deterministic() -> None:
+    first = export_petri_net_prism(_net(), Marking(tokens={"warmup": 1})).model
+    second = export_petri_net_prism(_net(), Marking(tokens={"warmup": 1})).model
+
+    assert first == second
+
+
+def test_petri_net_prism_export_rejects_bad_token_bound() -> None:
+    with pytest.raises(PolicyError, match="max_tokens"):
+        export_petri_net_prism(_net(), Marking(tokens={"warmup": 1}), max_tokens=0)
+
+
+def test_petri_net_prism_export_rejects_initial_tokens_above_bound() -> None:
+    with pytest.raises(PolicyError, match="exceeds max_tokens"):
+        export_petri_net_prism(_net(), Marking(tokens={"warmup": 3}), max_tokens=2)
+
+
+def _rules() -> list[PolicyRule]:
+    return [
+        PolicyRule(
+            name="boost K",
+            regimes=["DEGRADED", "CRITICAL"],
+            condition=PolicyCondition(
+                metric="R_good",
+                layer=0,
+                op="<",
+                threshold=0.6,
+            ),
+            actions=[PolicyAction(knob="K", scope="global", value=0.1, ttl_s=5.0)],
+            max_fires=2,
+        ),
+        PolicyRule(
+            name="damp_bad",
+            regimes=["CRITICAL"],
+            condition=CompoundCondition(
+                conditions=[
+                    PolicyCondition(
+                        metric="R_bad",
+                        layer=0,
+                        op=">",
+                        threshold=0.4,
+                    ),
+                    PolicyCondition(
+                        metric="stability_proxy",
+                        layer=None,
+                        op="<=",
+                        threshold=0.5,
+                    ),
+                ],
+                logic="AND",
+            ),
+            actions=[
+                PolicyAction(knob="alpha", scope="layer_0", value=-0.05, ttl_s=3.0)
+            ],
+        ),
+    ]
+
+
+def test_policy_rules_prism_export_serialises_rules_and_actions() -> None:
+    export = export_policy_rules_prism(_rules(), module_name="policy model")
+
+    assert export.rule_names == {"boost K": "boost_K", "damp_bad": "damp_bad"}
+    assert export.metric_names == {
+        "R_bad.0": "R_bad_0",
+        "R_good.0": "R_good_0",
+        "stability_proxy": "stability_proxy",
+    }
+    assert "module policy_model" in export.model
+    assert "//   CRITICAL -> 0" in export.model
+    assert "//   DEGRADED -> 1" in export.model
+    assert "boost_K_fires : [0..2] init 0;" in export.model
+    assert "damp_bad_fires : [0..1] init 0;" in export.model
+    assert "[boost_K] (regime = 1 | regime = 0) & R_good_0 < 0.59999999999999998" in (
+        export.model
+    )
+    assert (
+        "[damp_bad] (regime = 0) & "
+        "(R_bad_0 > 0.40000000000000002 & stability_proxy <= 0.5)"
+    ) in export.model
+    assert 'label "fires_boost_K" = boost_K_fires > 0;' in export.model
+    assert 'label "emits_boost_K_K_global_0" = boost_K_fires > 0;' in export.model
+
+
+def test_policy_rules_prism_export_rejects_bad_rules() -> None:
+    with pytest.raises(PolicyError, match="without rules"):
+        export_policy_rules_prism([])
+
+    bad = PolicyRule(
+        name="bad",
+        regimes=["DEGRADED"],
+        condition=PolicyCondition(metric="R", layer=0, op="!=", threshold=0.1),
+        actions=[PolicyAction(knob="K", scope="global", value=0.1, ttl_s=1.0)],
+    )
+    with pytest.raises(PolicyError, match="unsupported operator"):
+        export_policy_rules_prism([bad])
+
+
+def test_formal_export_cli_writes_prism_model(tmp_path: Path) -> None:
+    spec = {
+        "name": "formal-test",
+        "version": "1.0.0",
+        "safety_tier": "research",
+        "sample_period_s": 0.01,
+        "control_period_s": 0.01,
+        "layers": [
+            {"name": "L1", "index": 0, "oscillator_ids": ["o0", "o1"]},
+        ],
+        "oscillator_families": {
+            "p": {"channel": "P", "extractor_type": "hilbert"},
+        },
+        "coupling": {"base_strength": 0.45, "decay_alpha": 0.3},
+        "drivers": {"physical": {}, "informational": {}, "symbolic": {}},
+        "objectives": {"good_layers": [0], "bad_layers": []},
+        "boundaries": [],
+        "actuators": [],
+        "protocol_net": {
+            "places": ["warmup", "nominal"],
+            "initial": {"warmup": 1},
+            "place_regime": {"warmup": "NOMINAL", "nominal": "NOMINAL"},
+            "transitions": [
+                {
+                    "name": "start",
+                    "inputs": [{"place": "warmup"}],
+                    "outputs": [{"place": "nominal"}],
+                    "guard": "stability_proxy > 0.0",
+                },
+            ],
+        },
+    }
+    spec_path = tmp_path / "binding_spec.yaml"
+    out_path = tmp_path / "protocol.prism"
+    spec_path.write_text(yaml.safe_dump(spec), encoding="utf-8")
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "formal-export",
+            str(spec_path),
+            "--output",
+            str(out_path),
+            "--module-name",
+            "formal_test",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "PRISM model written:" in result.output
+    model = out_path.read_text(encoding="utf-8")
+    assert "module formal_test" in model
+    assert "[start] stability_proxy > 0 & warmup >= 1" in model
+
+
+def test_formal_export_cli_writes_policy_prism_model(tmp_path: Path) -> None:
+    spec = {
+        "name": "formal-policy-test",
+        "version": "1.0.0",
+        "safety_tier": "research",
+        "sample_period_s": 0.01,
+        "control_period_s": 0.01,
+        "layers": [
+            {"name": "L1", "index": 0, "oscillator_ids": ["o0", "o1"]},
+        ],
+        "oscillator_families": {
+            "p": {"channel": "P", "extractor_type": "hilbert"},
+        },
+        "coupling": {"base_strength": 0.45, "decay_alpha": 0.3},
+        "drivers": {"physical": {}, "informational": {}, "symbolic": {}},
+        "objectives": {"good_layers": [0], "bad_layers": []},
+        "boundaries": [],
+        "actuators": [],
+    }
+    policy = {
+        "rules": [
+            {
+                "name": "boost",
+                "regime": ["DEGRADED"],
+                "condition": {
+                    "metric": "R_good",
+                    "layer": 0,
+                    "op": "<",
+                    "threshold": 0.7,
+                },
+                "action": {"knob": "K", "scope": "global", "value": 0.1, "ttl_s": 5.0},
+            }
+        ]
+    }
+    spec_path = tmp_path / "binding_spec.yaml"
+    policy_path = tmp_path / "policy.yaml"
+    out_path = tmp_path / "policy.prism"
+    spec_path.write_text(yaml.safe_dump(spec), encoding="utf-8")
+    policy_path.write_text(yaml.safe_dump(policy), encoding="utf-8")
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "formal-export",
+            str(spec_path),
+            "--export",
+            "policy",
+            "--output",
+            str(out_path),
+            "--module-name",
+            "policy_test",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "PRISM model written:" in result.output
+    model = out_path.read_text(encoding="utf-8")
+    assert "module policy_test" in model
+    assert "[boost] (regime = 0) & R_good_0 < 0.69999999999999996" in model
+
+
+def test_formal_export_cli_requires_protocol_net(tmp_path: Path) -> None:
+    spec = {
+        "name": "formal-test",
+        "version": "1.0.0",
+        "safety_tier": "research",
+        "sample_period_s": 0.01,
+        "control_period_s": 0.01,
+        "layers": [
+            {"name": "L1", "index": 0, "oscillator_ids": ["o0", "o1"]},
+        ],
+        "oscillator_families": {
+            "p": {"channel": "P", "extractor_type": "hilbert"},
+        },
+        "coupling": {"base_strength": 0.45, "decay_alpha": 0.3},
+        "drivers": {"physical": {}, "informational": {}, "symbolic": {}},
+        "objectives": {"good_layers": [0], "bad_layers": []},
+        "boundaries": [],
+        "actuators": [],
+    }
+    spec_path = tmp_path / "binding_spec.yaml"
+    spec_path.write_text(yaml.safe_dump(spec), encoding="utf-8")
+
+    result = CliRunner().invoke(main, ["formal-export", str(spec_path)])
+
+    assert result.exit_code == 1
+    assert "ERROR: binding spec has no protocol_net" in result.output

--- a/tests/test_nchannel_acceptance.py
+++ b/tests/test_nchannel_acceptance.py
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Commercial license available
+# © Concepts 1996–2026 Miroslav Šotek. All rights reserved.
+# © Code 2020–2026 Miroslav Šotek. All rights reserved.
+# ORCID: 0009-0009-3560-0851
+# Contact: www.anulum.li | protoscience@anulum.li
+# SCPN Phase Orchestrator — N-channel audit/report acceptance tests
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from click.testing import CliRunner
+
+from scpn_phase_orchestrator.audit.logger import AuditLogger
+from scpn_phase_orchestrator.audit.replay import ReplayEngine
+from scpn_phase_orchestrator.cli import main
+from scpn_phase_orchestrator.reporting.explainability import (
+    build_explainability_report,
+)
+from scpn_phase_orchestrator.reporting.plots import CoherencePlot
+from scpn_phase_orchestrator.upde.metrics import LayerState, UPDEState
+from scpn_phase_orchestrator.visualization.network import (
+    coupling_heatmap_json,
+    network_graph_json,
+)
+from scpn_phase_orchestrator.visualization.torus import (
+    phase_wheel_json,
+    torus_points_json,
+)
+
+CHANNEL_NAMES = ["P", "I", "S", "H", "Risk"]
+
+
+def _state(values: list[float], regime: str = "NOMINAL") -> UPDEState:
+    return UPDEState(
+        layers=[
+            LayerState(R=value, psi=0.1 * (idx + 1)) for idx, value in enumerate(values)
+        ],
+        cross_layer_alignment=np.eye(len(values)),
+        stability_proxy=sum(values) / len(values),
+        regime_id=regime,
+    )
+
+
+def _step(step: int, values: list[float]) -> dict[str, Any]:
+    return {
+        "step": step,
+        "regime": "NOMINAL" if step == 0 else "DEGRADED",
+        "stability": sum(values) / len(values),
+        "layers": [
+            {"R": value, "psi": 0.1 * (idx + 1)} for idx, value in enumerate(values)
+        ],
+        "actions": [],
+    }
+
+
+def test_audit_and_replay_preserve_five_channel_layer_records(tmp_path: Path) -> None:
+    log_path = tmp_path / "audit.jsonl"
+    binding_config = {
+        "channels": {
+            name: {"driver_keys": [f"{name.lower()}_signal"]} for name in CHANNEL_NAMES
+        },
+        "channel_groups": {
+            "all_control": {"channels": CHANNEL_NAMES, "required": True},
+        },
+        "cross_channel_couplings": [
+            {"source": "H", "target": "I", "strength": 0.35},
+            {"source": "Risk", "target": "S", "strength": 0.42},
+        ],
+    }
+    with AuditLogger(log_path) as logger:
+        logger.log_header(
+            n_oscillators=8,
+            dt=0.01,
+            binding_config=binding_config,
+        )
+        logger.log_step(0, _state([0.91, 0.82, 0.73, 0.64, 0.55]), [])
+
+    replay = ReplayEngine(log_path)
+    entries = replay.load()
+    header = replay.load_header(entries)
+    assert header is not None
+    assert set(header["binding_config"]["channels"]) == set(CHANNEL_NAMES)
+
+    reconstructed = replay.replay_step(entries[1])
+    assert len(reconstructed.layers) == 5
+    assert reconstructed.cross_layer_alignment.shape == (5, 5)
+    assert [round(layer.R, 2) for layer in reconstructed.layers] == [
+        0.91,
+        0.82,
+        0.73,
+        0.64,
+        0.55,
+    ]
+
+
+def test_cli_report_counts_late_appearing_fifth_channel(tmp_path: Path) -> None:
+    log_path = tmp_path / "nchannel.jsonl"
+    entries = [
+        _step(0, [0.8, 0.7, 0.6, 0.5]),
+        _step(1, [0.81, 0.71, 0.61, 0.51, 0.41]),
+    ]
+    log_path.write_text(
+        "\n".join(json.dumps(entry) for entry in entries) + "\n",
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(main, ["report", str(log_path), "--json-out"])
+
+    assert result.exit_code == 0
+    summary = json.loads(result.output)
+    assert summary["layers"] == 5
+    assert summary["layer_r_final"] == [0.81, 0.71, 0.61, 0.51, 0.41]
+
+
+def test_reporting_extractors_keep_all_five_channels() -> None:
+    steps = [
+        _step(0, [0.8, 0.7, 0.6, 0.5]),
+        _step(1, [0.81, 0.71, 0.61, 0.51, 0.41]),
+    ]
+
+    plot = CoherencePlot(steps)
+    _, n_layers, r_series = plot._extract_r_series()
+    report = build_explainability_report(steps)
+
+    assert n_layers == 5
+    assert r_series[4] == [0.0, 0.41]
+    assert report.layers == 5
+    assert any("Layer 4:" in line for line in report.metric_summary)
+
+
+def test_visualisation_helpers_accept_five_channel_payloads() -> None:
+    phases = np.linspace(0.0, 2.0 * np.pi, len(CHANNEL_NAMES), endpoint=False)
+    couplings = np.array(
+        [
+            [0.0, 0.2, 0.1, 0.0, 0.4],
+            [0.2, 0.0, 0.3, 0.5, 0.0],
+            [0.1, 0.3, 0.0, 0.2, 0.6],
+            [0.0, 0.5, 0.2, 0.0, 0.7],
+            [0.4, 0.0, 0.6, 0.7, 0.0],
+        ]
+    )
+    r_values = [0.91, 0.82, 0.73, 0.64, 0.55]
+
+    graph = json.loads(network_graph_json(couplings, CHANNEL_NAMES, r_values))
+    heatmap = json.loads(coupling_heatmap_json(couplings, CHANNEL_NAMES))
+    wheel = json.loads(phase_wheel_json(phases, CHANNEL_NAMES))
+    torus = json.loads(torus_points_json(phases, r_values))
+
+    assert [node["name"] for node in graph["nodes"]] == CHANNEL_NAMES
+    assert heatmap["labels"] == CHANNEL_NAMES
+    assert [entry["name"] for entry in wheel["oscillators"]] == CHANNEL_NAMES
+    assert len(torus["points"]) == len(CHANNEL_NAMES)

--- a/tests/test_new_domainpacks.py
+++ b/tests/test_new_domainpacks.py
@@ -13,9 +13,17 @@ from pathlib import Path
 import pytest
 
 from scpn_phase_orchestrator.binding.loader import load_binding_spec
+from scpn_phase_orchestrator.binding.validator import validate_binding_spec
 from scpn_phase_orchestrator.server import SimulationState
+from scpn_phase_orchestrator.supervisor.policy_rules import load_policy_rules
 
 DOMAINPACK_DIR = Path(__file__).parent.parent / "domainpacks"
+
+NCHANNEL_PACKS = [
+    "digital_twin_nchannel",
+    "edge_consensus_nchannel",
+    "power_safety_nchannel",
+]
 
 NEW_PACKS = [
     "financial_markets",
@@ -35,6 +43,7 @@ NEW_PACKS = [
     "satellite_constellation",
     "swarm_robotics",
     "traffic_flow",
+    *NCHANNEL_PACKS,
 ]
 
 
@@ -99,6 +108,35 @@ def test_domainpack_reset_restores_step_zero(pack: str) -> None:
         sim.step()
     reset_state = sim.reset()
     assert reset_state["step"] == 0
+
+
+@pytest.mark.parametrize("pack", NCHANNEL_PACKS)
+def test_nchannel_domainpack_declares_channel_algebra(pack: str) -> None:
+    """N-channel examples must exercise groups, derived channels, and
+    cross-channel coupling rather than only renaming P/I/S."""
+    spec = load_binding_spec(DOMAINPACK_DIR / pack / "binding_spec.yaml")
+    errors = validate_binding_spec(spec)
+    assert not errors
+    assert len(spec.used_channels()) > 3
+    assert len(spec.channel_groups) >= 2
+    assert len(spec.cross_channel_couplings) >= 3
+    derived = [
+        (name, channel)
+        for name, channel in spec.channels.items()
+        if channel.derived_from and channel.replay_semantics == "derived"
+    ]
+    assert derived
+    for _, channel in derived:
+        assert channel.derive_rule
+        assert channel.supervisor_visibility is True
+
+
+@pytest.mark.parametrize("pack", NCHANNEL_PACKS)
+def test_nchannel_domainpack_policy_loads(pack: str) -> None:
+    """The examples must ship an executable policy next to the binding."""
+    rules = load_policy_rules(DOMAINPACK_DIR / pack / "policy.yaml")
+    assert len(rules) >= 2
+    assert all(rule.actions for rule in rules)
 
 
 def test_missing_domainpack_raises_clear_error() -> None:

--- a/tests/test_petri_net_parity.py
+++ b/tests/test_petri_net_parity.py
@@ -195,5 +195,34 @@ def test_place_names_parity(spo):
     assert set(py_net.place_names) == set(rust_net.place_names)
 
 
+def test_rust_petri_net_exposes_transition_and_active_place_diagnostics(spo):
+    rust_net = _rust_simple_net(spo)
+    if not all(
+        hasattr(rust_net, attr) for attr in ("transition_names", "active_places")
+    ):
+        pytest.skip("installed spo_kernel lacks PyPetriNet diagnostics")
+
+    assert rust_net.transition_names == ["start", "finish"]
+    assert rust_net.active_places({"idle": 1, "active": 0}) == ["idle"]
+
+
+def test_rust_petri_net_rejects_invalid_surface(spo):
+    probe = _rust_simple_net(spo)
+    if not hasattr(probe, "transition_names"):
+        pytest.skip("installed spo_kernel lacks PyPetriNet validation slice")
+
+    with pytest.raises(ValueError, match="place names must not be empty"):
+        spo.PyPetriNet([""], [])
+
+    with pytest.raises(ValueError, match="transition names must not be empty"):
+        spo.PyPetriNet(["a"], [("", [], [], None)])
+
+    with pytest.raises(ValueError, match="zero-weight arc"):
+        spo.PyPetriNet(["a"], [("bad", [("a", 0)], [], None)])
+
+    with pytest.raises(ValueError, match="threshold must be finite"):
+        spo.PyPetriNet(["a"], [("bad", [("a", 1)], [], "x > NaN")])
+
+
 # Pipeline wiring: the parity tests above cross-validate
 # Rust PyPetriNet against Python PetriNet.

--- a/tests/test_policy_diagnostics.py
+++ b/tests/test_policy_diagnostics.py
@@ -1,0 +1,174 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Commercial license available
+# © Concepts 1996–2026 Miroslav Šotek. All rights reserved.
+# © Code 2020–2026 Miroslav Šotek. All rights reserved.
+# ORCID: 0009-0009-3560-0851
+# Contact: www.anulum.li | protoscience@anulum.li
+# SCPN Phase Orchestrator — Policy dry-run diagnostics tests
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+from click.testing import CliRunner
+
+from scpn_phase_orchestrator.cli import main
+from scpn_phase_orchestrator.supervisor.policy_diagnostics import (
+    dry_run_policy_rules,
+)
+from scpn_phase_orchestrator.supervisor.policy_rules import load_policy_rules
+
+
+def _entries() -> list[dict[str, Any]]:
+    return [
+        {
+            "step": 0,
+            "regime": "DEGRADED",
+            "stability": 0.4,
+            "layers": [{"R": 0.8, "psi": 0.0}, {"R": 0.2, "psi": 0.0}],
+        },
+        {
+            "step": 1,
+            "regime": "CRITICAL",
+            "stability": 0.2,
+            "layers": [{"R": 0.7, "psi": 0.0}, {"R": 0.1, "psi": 0.0}],
+        },
+    ]
+
+
+def _policy_data() -> dict[str, Any]:
+    return {
+        "rules": [
+            {
+                "name": "boost_degraded",
+                "regime": ["DEGRADED"],
+                "condition": {
+                    "metric": "stability_proxy",
+                    "op": "<",
+                    "threshold": 0.5,
+                },
+                "action": {
+                    "knob": "K",
+                    "scope": "global",
+                    "value": 0.1,
+                    "ttl_s": 5.0,
+                },
+            },
+            {
+                "name": "suppress_bad",
+                "regime": ["CRITICAL"],
+                "condition": {
+                    "metric": "R_bad",
+                    "layer": 0,
+                    "op": "<",
+                    "threshold": 0.2,
+                },
+                "action": {
+                    "knob": "K",
+                    "scope": "layer_1",
+                    "value": -0.1,
+                    "ttl_s": 5.0,
+                },
+            },
+            {
+                "name": "never_fires",
+                "regime": ["NOMINAL"],
+                "condition": {
+                    "metric": "R",
+                    "layer": 0,
+                    "op": ">",
+                    "threshold": 0.9,
+                },
+                "action": {
+                    "knob": "zeta",
+                    "scope": "global",
+                    "value": 0.1,
+                    "ttl_s": 5.0,
+                },
+            },
+        ]
+    }
+
+
+def _binding_data() -> dict[str, Any]:
+    return {
+        "name": "policy-dry-run-test",
+        "version": "1.0.0",
+        "safety_tier": "research",
+        "sample_period_s": 0.01,
+        "control_period_s": 0.01,
+        "layers": [
+            {"name": "good", "index": 0, "oscillator_ids": ["g0"]},
+            {"name": "bad", "index": 1, "oscillator_ids": ["b0"]},
+        ],
+        "oscillator_families": {
+            "p": {"channel": "P", "extractor_type": "hilbert"},
+        },
+        "coupling": {"base_strength": 0.45, "decay_alpha": 0.3},
+        "drivers": {"physical": {}, "informational": {}, "symbolic": {}},
+        "objectives": {"good_layers": [0], "bad_layers": [1]},
+        "boundaries": [],
+        "actuators": [],
+    }
+
+
+def test_policy_dry_run_reports_unreachable_rules(tmp_path: Path) -> None:
+    policy_path = tmp_path / "policy.yaml"
+    policy_path.write_text(yaml.safe_dump(_policy_data()), encoding="utf-8")
+    rules = load_policy_rules(policy_path)
+
+    report = dry_run_policy_rules(
+        rules,
+        _entries(),
+        good_layers=[0],
+        bad_layers=[1],
+    )
+
+    assert report.steps == 2
+    assert report.fire_counts["boost_degraded"] == 1
+    assert report.fire_counts["suppress_bad"] == 1
+    assert report.unreachable_rules == ("never_fires",)
+    assert report.step_reports[0].fired_rules == ("boost_degraded",)
+
+
+def test_policy_dry_run_cli_outputs_json(tmp_path: Path) -> None:
+    binding_path = tmp_path / "binding_spec.yaml"
+    policy_path = tmp_path / "policy.yaml"
+    audit_path = tmp_path / "audit.jsonl"
+    binding_path.write_text(yaml.safe_dump(_binding_data()), encoding="utf-8")
+    policy_path.write_text(yaml.safe_dump(_policy_data()), encoding="utf-8")
+    audit_path.write_text(
+        "\n".join(json.dumps(entry) for entry in _entries()) + "\n",
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(
+        main,
+        ["policy-dry-run", str(binding_path), str(audit_path), "--json-out"],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["steps"] == 2
+    assert payload["fire_counts"]["boost_degraded"] == 1
+    assert payload["unreachable_rules"] == ["never_fires"]
+
+
+def test_policy_dry_run_cli_rejects_missing_policy(tmp_path: Path) -> None:
+    binding_path = tmp_path / "binding_spec.yaml"
+    audit_path = tmp_path / "audit.jsonl"
+    binding_path.write_text(yaml.safe_dump(_binding_data()), encoding="utf-8")
+    audit_path.write_text(
+        "\n".join(json.dumps(entry) for entry in _entries()) + "\n",
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(
+        main, ["policy-dry-run", str(binding_path), str(audit_path)]
+    )
+
+    assert result.exit_code == 1
+    assert "ERROR: policy file not found:" in result.output

--- a/tests/test_rule_engine_parity.py
+++ b/tests/test_rule_engine_parity.py
@@ -194,6 +194,67 @@ def test_max_fires_parity(spo):
     assert len(rust_eng.evaluate("degraded", ctx)) == 0
 
 
+def test_rust_rule_engine_exposes_fire_diagnostics(spo):
+    rust_eng = spo.PyRuleEngine(
+        [_rust_rule("boost", "DEGRADED", "stability_proxy", "<", 0.5)]
+    )
+    if not all(
+        hasattr(rust_eng, attr)
+        for attr in ("rule_names", "fire_counts", "fire_count", "last_fire_time")
+    ):
+        pytest.skip("installed spo_kernel lacks PyRuleEngine diagnostics")
+
+    assert rust_eng.rule_names == ["boost"]
+    assert rust_eng.fire_count("boost") == 0
+    assert rust_eng.fire_counts == {}
+    assert rust_eng.last_fire_time("boost") is None
+
+    assert len(rust_eng.evaluate("degraded", {"stability_proxy": 0.3})) == 1
+
+    assert rust_eng.fire_count("boost") == 1
+    assert rust_eng.fire_counts == {"boost": 1}
+    assert rust_eng.last_fire_time("boost") == 0.0
+    assert rust_eng.last_fire_times == {"boost": 0.0}
+
+
+def test_rust_rule_engine_rejects_invalid_policy_surface(spo):
+    probe = spo.PyRuleEngine(
+        [_rust_rule("probe", "DEGRADED", "stability_proxy", "<", 0.5)]
+    )
+    if not hasattr(probe, "rule_names"):
+        pytest.skip("installed spo_kernel lacks PyRuleEngine diagnostics slice")
+
+    with pytest.raises(ValueError, match="unknown rule logic"):
+        spo.PyRuleEngine(
+            [
+                (
+                    "bad_logic",
+                    ["DEGRADED"],
+                    [("a", ">", 0.0), ("b", "<", 1.0)],
+                    "XOR",
+                    [("K", "global", 0.1, 1.0)],
+                    0.0,
+                    0,
+                )
+            ]
+        )
+
+    with pytest.raises(ValueError, match="actions must not be empty"):
+        spo.PyRuleEngine(
+            [
+                (
+                    "empty_actions",
+                    ["DEGRADED"],
+                    [("stability_proxy", "<", 0.5)],
+                    "AND",
+                    [],
+                    0.0,
+                    0,
+                )
+            ]
+        )
+
+
 def test_compound_and_parity(spo):
     py_rule = PolicyRule(
         name="compound",


### PR DESCRIPTION
## Summary
- Adds three runnable N-channel domainpacks for digital twins, edge consensus, and power safety.
- Tightens N-channel binding validation and adds channel-count agnostic audit/report/visualisation acceptance tests.
- Adds supervisor policy dry-run diagnostics and PRISM formal export hooks.
- Extends Rust spo-types/supervisor surfaces with channel metrics, rule diagnostics, and Petri net diagnostics.

## Local Validation
- pre-push preflight: all 10 gates passed locally before push
- focused pytest: 639 passed, 5 skipped
- full pre-push pytest: passed during preflight
- cargo test / clippy / fmt: passed during preflight

## Notes
- Full remote CI must pass before merge.