### PR TITLE
ci(release): fix sdist build dependency installation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Build sdist
         run: |
-          pip install --require-hashes --no-deps -r requirements/release-tools.txt
+          pip install --require-hashes -r requirements/release-tools.txt
           python -m build --sdist
 
       - name: Generate SBOM


### PR DESCRIPTION
Release workflow failed on tag v0.5.0 with ModuleNotFoundError: pyproject_hooks because build was installed with --no-deps. This change keeps hash pinning and allows build dependencies to install.