### PR TITLE
ci(release): fix hashed build install with explicit backend deps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,8 @@ jobs:
 
       - name: Build sdist
         run: |
-          pip install --require-hashes -r requirements/release-tools.txt
+          pip install --require-hashes --no-deps -r requirements/release-tools.txt
+          pip install pyproject_hooks==1.2.0 packaging==25.0
           python -m build --sdist
 
       - name: Generate SBOM


### PR DESCRIPTION
Follow-up release workflow fix: keep hashed/no-deps install for release-tools and add explicit pyproject_hooks + packaging install before sdist build.