### PR TITLE
ci(release): install full dev lock for SBOM generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Generate SBOM
         run: |
-          pip install --require-hashes --no-deps -r requirements/dev-lock.txt && pip install --no-deps -e .
+          pip install --require-hashes -r requirements/dev-lock.txt && pip install --no-deps -e .
           cyclonedx-py environment -o sbom.json --output-format json
 
       - name: Extract changelog


### PR DESCRIPTION
## Summary
- install full  dependency graph in Release SBOM step
- keep editable install no-deps as before
- fix  import failure in tag release workflow

## Validation
- inspected failed run 25231218814 ( in Generate SBOM)
