### PR TITLE
ci(release): simplify SBOM dependency bootstrap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,9 @@ jobs:
 
       - name: Generate SBOM
         run: |
-          pip install --require-hashes -r requirements/dev-lock.txt && pip install --no-deps -e .
+          pip install --require-hashes --no-deps -r requirements/release-tools.txt
+          pip install cyclonedx-bom
+          pip install --no-deps -e .
           cyclonedx-py environment -o sbom.json --output-format json
 
       - name: Extract changelog


### PR DESCRIPTION
## Summary
- avoid full `dev-lock` installation in release SBOM step
- install hash-locked release tool set (`--no-deps`) plus `cyclonedx-bom`
- keep editable package install for project metadata scanning

## Why
The previous step failed under hash mode because transitive `setuptools>=77.0.1` (via `grpcio-tools`) is unpinned.
