### PR TITLE
chore: prepare 0.5.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed (2026-05-06 — PyPI publish release guards)
+## [0.5.5] - 2026-05-06
+
+### Fixed
 - Added `tools/check_release_tag_version.py` and focused tests so tag-triggered
   release workflows fail early when `GITHUB_REF_NAME` does not match the Python
   package version in `pyproject.toml`.
@@ -1430,7 +1432,8 @@ proxy to the full arXiv:2603.15031 Transformer architecture:
 - Module linkage guard (`tools/check_test_module_linkage.py`) requiring test files for all source modules
 - Rust kernel (`spo-kernel/`) with PyO3 bindings for UPDEEngine, RegimeManager, CoherenceMonitor
 
-[Unreleased]: https://github.com/anulum/scpn-phase-orchestrator/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/anulum/scpn-phase-orchestrator/compare/v0.5.5...HEAD
+[0.5.5]: https://github.com/anulum/scpn-phase-orchestrator/compare/v0.5.0...v0.5.5
 [0.5.0]: https://github.com/anulum/scpn-phase-orchestrator/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/anulum/scpn-phase-orchestrator/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/anulum/scpn-phase-orchestrator/compare/v0.3.0...v0.4.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,8 +7,8 @@ authors:
     given-names: Miroslav
     orcid: "https://orcid.org/0009-0009-3560-0851"
     email: protoscience@anulum.li
-version: 0.5.0
-date-released: "2026-03-04"
+version: 0.5.5
+date-released: "2026-05-06"
 license: AGPL-3.0-or-later
 url: "https://github.com/anulum/scpn-phase-orchestrator"
 repository-code: "https://github.com/anulum/scpn-phase-orchestrator"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Domain-agnostic coherence control compiler built on Kuramoto/UPDE phase dynamics
 
 > **Active Development** — SCPN Phase Orchestrator is under intensive development. The core UPDE engine, all 12 integration methods, 3-channel oscillator extraction (P/I/S), supervisor with regime management, and Rust FFI acceleration are fully functional and tested (3 945 Python tests passed, 567 Rust tests, zero functional failures). Rust FFI coverage now spans 53 engine modules across UPDE, coupling, monitor, SSGF, and autotune subsystems with a reference documentation page for every Rust-accelerated module. APIs may evolve as this work progresses.
 
-**Version:** 0.5.0
+**Version:** 0.5.5
 **Status:** 142 Python Modules | 12 Engine Variants | 19 Monitors | 36 Domainpacks | 53 Rust Engine Modules | 567 Rust Tests | 3 945 Python Tests Passed
 
 [![CI](https://github.com/anulum/scpn-phase-orchestrator/actions/workflows/ci.yml/badge.svg)](https://github.com/anulum/scpn-phase-orchestrator/actions/workflows/ci.yml)

--- a/docs/VALIDATION_REPORT.md
+++ b/docs/VALIDATION_REPORT.md
@@ -8,7 +8,7 @@ Contact: www.anulum.li | protoscience@anulum.li
 
 # Software Verification & Validation Report
 
-**Version:** 0.5.0
+**Version:** 0.5.5
 **Date:** 2026-03-28
 **Author:** Miroslav Šotek / Arcane Sapience
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scpn-phase-orchestrator"
-version = "0.5.0"
+version = "0.5.5"
 description = "Domain-agnostic coherence control compiler built on SCPN's Kuramoto/UPDE framework"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/spo-kernel/Cargo.lock
+++ b/spo-kernel/Cargo.lock
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "spo-engine"
-version = "0.5.0"
+version = "0.5.5"
 dependencies = [
  "criterion",
  "proptest",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "spo-ffi"
-version = "0.5.0"
+version = "0.5.5"
 dependencies = [
  "numpy",
  "pyo3",
@@ -848,14 +848,14 @@ dependencies = [
 
 [[package]]
 name = "spo-oscillators"
-version = "0.5.0"
+version = "0.5.5"
 dependencies = [
  "spo-types",
 ]
 
 [[package]]
 name = "spo-supervisor"
-version = "0.5.0"
+version = "0.5.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "spo-types"
-version = "0.5.0"
+version = "0.5.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "spo-wasm"
-version = "0.5.0"
+version = "0.5.5"
 dependencies = [
  "js-sys",
  "serde",

--- a/spo-kernel/Cargo.toml
+++ b/spo-kernel/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.5"
 edition = "2021"
 rust-version = "1.83.0"
 authors = ["Miroslav Sotek <protoscience@anulum.li>"]

--- a/spo-kernel/crates/spo-ffi/pyproject.toml
+++ b/spo-kernel/crates/spo-ffi/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = "maturin"
 
 [project]
 name = "spo-kernel"
-version = "0.5.0"
+version = "0.5.5"
 description = "SCPN Phase Orchestrator — Rust-accelerated UPDE kernel"
 authors = [{name = "Miroslav Sotek", email = "protoscience@anulum.li"}]
 requires-python = ">=3.10"

--- a/src/scpn_phase_orchestrator/server.py
+++ b/src/scpn_phase_orchestrator/server.py
@@ -422,7 +422,7 @@ def create_app(spec_path: str | Path) -> object:  # pragma: no cover
             with sim._lock:
                 sim.event_bus.clear()
 
-    app = FastAPI(title="SPO Dashboard", version="0.5.0", lifespan=_lifespan)
+    app = FastAPI(title="SPO Dashboard", version="0.5.5", lifespan=_lifespan)
 
     @app.middleware("http")
     async def _log_http_request(


### PR DESCRIPTION
## Summary\n- Bump Python and Rust package metadata to 0.5.5\n- Move release-guard changelog notes under 0.5.5\n- Update user-visible version metadata and citation release date\n\n## Validation\n- Local pre-push gate passed twice\n- version-sync passed\n- release tag guard passed for v0.5.5\n- focused pytest/server tests passed\n- isolated publish build produced 0.5.5 sdist/wheel and twine check passed\n- cargo test --workspace --exclude spo-ffi passed\n\nCo-Authored-By: Arcane Sapience <protoscience@anulum.li>