### PR TITLE
Prepare 0.5.6 release retry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,7 @@ jobs:
   preflight:
     name: Pre-publish CI gate
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
@@ -33,7 +34,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - run: pip install --require-hashes --no-deps -r requirements/dev-lock.txt && pip install --no-deps -e .
       - run: ruff check src/ tests/
-      - run: pytest tests/ -x --tb=short
+      - name: Run release preflight tests
+        timeout-minutes: 25
+        run: pytest tests/ -x -vv --tb=short --durations=25
       - run: python tools/check_version_sync.py
       - run: python tools/check_release_tag_version.py
       - run: cargo clippy --workspace --exclude spo-ffi -- -D warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.5.5] - 2026-05-06
+## [0.5.6] - 2026-05-06
 
 ### Fixed
+- Added a bounded, verbose PyPI publish preflight test step so release runs
+  fail with actionable diagnostics instead of hanging indefinitely during
+  full-suite pytest execution.
+- Moved release metadata from the canceled `v0.5.5` publish attempt to
+  `0.5.6`; the `v0.5.5` run was canceled before artifact build or PyPI publish.
 - Added `tools/check_release_tag_version.py` and focused tests so tag-triggered
   release workflows fail early when `GITHUB_REF_NAME` does not match the Python
   package version in `pyproject.toml`.
@@ -1432,8 +1437,8 @@ proxy to the full arXiv:2603.15031 Transformer architecture:
 - Module linkage guard (`tools/check_test_module_linkage.py`) requiring test files for all source modules
 - Rust kernel (`spo-kernel/`) with PyO3 bindings for UPDEEngine, RegimeManager, CoherenceMonitor
 
-[Unreleased]: https://github.com/anulum/scpn-phase-orchestrator/compare/v0.5.5...HEAD
-[0.5.5]: https://github.com/anulum/scpn-phase-orchestrator/compare/v0.5.0...v0.5.5
+[Unreleased]: https://github.com/anulum/scpn-phase-orchestrator/compare/v0.5.6...HEAD
+[0.5.6]: https://github.com/anulum/scpn-phase-orchestrator/compare/v0.5.0...v0.5.6
 [0.5.0]: https://github.com/anulum/scpn-phase-orchestrator/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/anulum/scpn-phase-orchestrator/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/anulum/scpn-phase-orchestrator/compare/v0.3.0...v0.4.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,7 +7,7 @@ authors:
     given-names: Miroslav
     orcid: "https://orcid.org/0009-0009-3560-0851"
     email: protoscience@anulum.li
-version: 0.5.5
+version: 0.5.6
 date-released: "2026-05-06"
 license: AGPL-3.0-or-later
 url: "https://github.com/anulum/scpn-phase-orchestrator"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Domain-agnostic coherence control compiler built on Kuramoto/UPDE phase dynamics
 
 > **Active Development** — SCPN Phase Orchestrator is under intensive development. The core UPDE engine, all 12 integration methods, 3-channel oscillator extraction (P/I/S), supervisor with regime management, and Rust FFI acceleration are fully functional and tested (3 945 Python tests passed, 567 Rust tests, zero functional failures). Rust FFI coverage now spans 53 engine modules across UPDE, coupling, monitor, SSGF, and autotune subsystems with a reference documentation page for every Rust-accelerated module. APIs may evolve as this work progresses.
 
-**Version:** 0.5.5
+**Version:** 0.5.6
 **Status:** 142 Python Modules | 12 Engine Variants | 19 Monitors | 36 Domainpacks | 53 Rust Engine Modules | 567 Rust Tests | 3 945 Python Tests Passed
 
 [![CI](https://github.com/anulum/scpn-phase-orchestrator/actions/workflows/ci.yml/badge.svg)](https://github.com/anulum/scpn-phase-orchestrator/actions/workflows/ci.yml)

--- a/docs/VALIDATION_REPORT.md
+++ b/docs/VALIDATION_REPORT.md
@@ -8,7 +8,7 @@ Contact: www.anulum.li | protoscience@anulum.li
 
 # Software Verification & Validation Report
 
-**Version:** 0.5.5
+**Version:** 0.5.6
 **Date:** 2026-03-28
 **Author:** Miroslav Šotek / Arcane Sapience
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scpn-phase-orchestrator"
-version = "0.5.5"
+version = "0.5.6"
 description = "Domain-agnostic coherence control compiler built on SCPN's Kuramoto/UPDE framework"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/spo-kernel/Cargo.lock
+++ b/spo-kernel/Cargo.lock
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "spo-engine"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "criterion",
  "proptest",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "spo-ffi"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "numpy",
  "pyo3",
@@ -848,14 +848,14 @@ dependencies = [
 
 [[package]]
 name = "spo-oscillators"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "spo-types",
 ]
 
 [[package]]
 name = "spo-supervisor"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "spo-types"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "spo-wasm"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "js-sys",
  "serde",

--- a/spo-kernel/Cargo.toml
+++ b/spo-kernel/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.5.5"
+version = "0.5.6"
 edition = "2021"
 rust-version = "1.83.0"
 authors = ["Miroslav Sotek <protoscience@anulum.li>"]

--- a/spo-kernel/crates/spo-ffi/pyproject.toml
+++ b/spo-kernel/crates/spo-ffi/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = "maturin"
 
 [project]
 name = "spo-kernel"
-version = "0.5.5"
+version = "0.5.6"
 description = "SCPN Phase Orchestrator — Rust-accelerated UPDE kernel"
 authors = [{name = "Miroslav Sotek", email = "protoscience@anulum.li"}]
 requires-python = ">=3.10"

--- a/src/scpn_phase_orchestrator/server.py
+++ b/src/scpn_phase_orchestrator/server.py
@@ -422,7 +422,7 @@ def create_app(spec_path: str | Path) -> object:  # pragma: no cover
             with sim._lock:
                 sim.event_bus.clear()
 
-    app = FastAPI(title="SPO Dashboard", version="0.5.5", lifespan=_lifespan)
+    app = FastAPI(title="SPO Dashboard", version="0.5.6", lifespan=_lifespan)
 
     @app.middleware("http")
     async def _log_http_request(


### PR DESCRIPTION
## Summary
- bump release metadata from the canceled v0.5.5 attempt to v0.5.6
- bound and expand the PyPI publish preflight pytest step with verbose diagnostics and slow-test durations
- document that v0.5.5 was canceled before artifact build or PyPI publication

## Validation
- tools/check_version_sync.py
- tools/check_release_tag_version.py with GITHUB_REF_NAME=v0.5.6
- focused release/server pytest suite
- isolated sdist/wheel build plus twine check for 0.5.6
- pre-push 11-gate hook