### PR TITLE
Prepare 0.5.8 release pin hardening

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,6 +33,9 @@ jobs:
           python-version: "3.12"
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - run: pip install --require-hashes --no-deps -r requirements/dev-lock.txt && pip install --no-deps -e .
+      - run: python tools/check_github_action_refs.py .github/workflows/publish.yml
+        env:
+          GH_TOKEN: ${{ github.token }}
       - run: ruff check src/ tests/
       - name: Run release preflight tests
         timeout-minutes: 25
@@ -80,7 +83,7 @@ jobs:
           python-version: "3.12"
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - name: Build wheel via maturin
-        uses: PyO3/maturin-action@aef21716426562a9d8f5d75e57a8cee3f3329592 # v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: ${{ matrix.target }}
           manylinux: auto
@@ -141,7 +144,7 @@ jobs:
         with:
           name: wheel-fallback
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@76f52bc884231f62b54a752f3a06f5a68aee2013 # release/v1
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
 
   build-container:
     name: Build, scan, and push container image
@@ -178,7 +181,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Scan image with Trivy
-        uses: aquasecurity/trivy-action@18f2510ee396bbf400402947e0f18c8ea7e3fd4d # v0.28.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ghcr.io/anulum/scpn-phase-orchestrator:${{ steps.meta.outputs.version }}
           format: table

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.5.7] - 2026-05-06
+## [0.5.8] - 2026-05-06
 
 ### Fixed
 - Aligned PyPI publish preflight test scope with the protected CI Python matrix
   so tag-triggered releases do not run the CPU-JAX physics-validation suite that
   is intentionally excluded from the standard CI path.
+- Replaced invalid pinned publish-workflow action refs for `PyO3/maturin-action`,
+  `pypa/gh-action-pypi-publish`, and `aquasecurity/trivy-action` with
+  resolvable commit pins.
+- Added `tools/check_github_action_refs.py` and tests so release preflight fails
+  before artifact fan-out when a pinned GitHub Action ref cannot be resolved.
+- Moved release metadata from the setup-failed `v0.5.7` publish attempt to
+  `0.5.8`; the `v0.5.7` run passed preflight and built pure-Python artifacts,
+  but failed before PyPI upload because multiple pinned action refs were invalid.
 - Moved release metadata from the timed-out `v0.5.6` publish attempt to
-  `0.5.7`; the `v0.5.6` run timed out before artifact build or PyPI publish.
+  `0.5.8`; the `v0.5.6` run timed out before artifact build or PyPI publish.
 - Added a bounded, verbose PyPI publish preflight test step so release runs
   fail with actionable diagnostics instead of hanging indefinitely during
   full-suite pytest execution.
@@ -1442,8 +1450,8 @@ proxy to the full arXiv:2603.15031 Transformer architecture:
 - Module linkage guard (`tools/check_test_module_linkage.py`) requiring test files for all source modules
 - Rust kernel (`spo-kernel/`) with PyO3 bindings for UPDEEngine, RegimeManager, CoherenceMonitor
 
-[Unreleased]: https://github.com/anulum/scpn-phase-orchestrator/compare/v0.5.7...HEAD
-[0.5.7]: https://github.com/anulum/scpn-phase-orchestrator/compare/v0.5.0...v0.5.7
+[Unreleased]: https://github.com/anulum/scpn-phase-orchestrator/compare/v0.5.8...HEAD
+[0.5.8]: https://github.com/anulum/scpn-phase-orchestrator/compare/v0.5.0...v0.5.8
 [0.5.0]: https://github.com/anulum/scpn-phase-orchestrator/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/anulum/scpn-phase-orchestrator/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/anulum/scpn-phase-orchestrator/compare/v0.3.0...v0.4.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,7 +7,7 @@ authors:
     given-names: Miroslav
     orcid: "https://orcid.org/0009-0009-3560-0851"
     email: protoscience@anulum.li
-version: 0.5.7
+version: 0.5.8
 date-released: "2026-05-06"
 license: AGPL-3.0-or-later
 url: "https://github.com/anulum/scpn-phase-orchestrator"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Domain-agnostic coherence control compiler built on Kuramoto/UPDE phase dynamics
 
 > **Active Development** — SCPN Phase Orchestrator is under intensive development. The core UPDE engine, all 12 integration methods, 3-channel oscillator extraction (P/I/S), supervisor with regime management, and Rust FFI acceleration are fully functional and tested (3 945 Python tests passed, 567 Rust tests, zero functional failures). Rust FFI coverage now spans 53 engine modules across UPDE, coupling, monitor, SSGF, and autotune subsystems with a reference documentation page for every Rust-accelerated module. APIs may evolve as this work progresses.
 
-**Version:** 0.5.7
+**Version:** 0.5.8
 **Status:** 142 Python Modules | 12 Engine Variants | 19 Monitors | 36 Domainpacks | 53 Rust Engine Modules | 567 Rust Tests | 3 945 Python Tests Passed
 
 [![CI](https://github.com/anulum/scpn-phase-orchestrator/actions/workflows/ci.yml/badge.svg)](https://github.com/anulum/scpn-phase-orchestrator/actions/workflows/ci.yml)

--- a/docs/RELEASE_HYGIENE.md
+++ b/docs/RELEASE_HYGIENE.md
@@ -1,0 +1,21 @@
+# Release Hygiene
+
+This project pins GitHub Actions by full commit SHA in release workflows. Before
+tagging a release, validate those pins so GitHub Actions does not fail during
+job setup after the tag has already been pushed.
+
+Run:
+
+```bash
+python tools/check_github_action_refs.py .github/workflows/publish.yml
+python tools/check_version_sync.py
+GITHUB_REF_NAME=vX.Y.Z python tools/check_release_tag_version.py
+```
+
+The action-reference guard checks every remote `owner/repo@ref` action in the
+workflow, requires full 40-character commit SHAs, and verifies each ref resolves
+through the GitHub API. Local actions and `docker://` actions are ignored.
+
+If a tag-triggered publish run fails before uploading, delete the failed tag,
+bump the release metadata, fix the workflow on a pull request, and tag the new
+version only after CI and the local release guards pass.

--- a/docs/RELEASE_HYGIENE.md
+++ b/docs/RELEASE_HYGIENE.md
@@ -19,3 +19,11 @@ through the GitHub API. Local actions and `docker://` actions are ignored.
 If a tag-triggered publish run fails before uploading, delete the failed tag,
 bump the release metadata, fix the workflow on a pull request, and tag the new
 version only after CI and the local release guards pass.
+
+## Fuzzing Findings
+
+ClusterFuzzLite failures are treated as release blockers when the crash is
+reproducible. For policy YAML fuzzing, malformed YAML parser failures must be
+contained at the loader boundary and reported as `ValueError` parse errors,
+rather than escaping as uncaught parser exceptions. Add a regression test with
+the minimized payload before rerunning or merging the release PR.

--- a/docs/VALIDATION_REPORT.md
+++ b/docs/VALIDATION_REPORT.md
@@ -8,7 +8,7 @@ Contact: www.anulum.li | protoscience@anulum.li
 
 # Software Verification & Validation Report
 
-**Version:** 0.5.7
+**Version:** 0.5.8
 **Date:** 2026-03-28
 **Author:** Miroslav Šotek / Arcane Sapience
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,6 +86,7 @@ nav:
       - "Notebook → Production": guide/notebook_to_production.md
       - Interactive Tools: guide/interactive_tools.md
       - Testing: guide/testing.md
+      - Release Hygiene: RELEASE_HYGIENE.md
       - Contributor Onboarding: guide/contributor_onboarding.md
       - Video Scripts: video_scripts.md
   - Specifications:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scpn-phase-orchestrator"
-version = "0.5.7"
+version = "0.5.8"
 description = "Domain-agnostic coherence control compiler built on SCPN's Kuramoto/UPDE framework"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/requirements/dev-lock-py311.txt
+++ b/requirements/dev-lock-py311.txt
@@ -1741,9 +1741,9 @@ mergedeep==1.3.4 \
     # via
     #   mkdocs
     #   mkdocs-get-deps
-mistune==3.2.0 \
-    --hash=sha256:708487c8a8cdd99c9d90eb3ed4c3ed961246ff78ac82f03418f5183ab70e398a \
-    --hash=sha256:febdc629a3c78616b94393c6580551e0e34cc289987ec6c35ed3f4be42d0eee1
+mistune==3.2.1 \
+    --hash=sha256:78cdb0ba5e938053ccf63651b352508d2efa9411dc8810bfb05f2dc5140c0048 \
+    --hash=sha256:7c8e5501d38bac1582e067e46c8343f17d57ea1aaa735823f3aba1fd59c88a28
     # via nbconvert
 mkdocs==1.6.1 \
     --hash=sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2 \

--- a/requirements/dev-lock-py313.txt
+++ b/requirements/dev-lock-py313.txt
@@ -1735,9 +1735,9 @@ mergedeep==1.3.4 \
     # via
     #   mkdocs
     #   mkdocs-get-deps
-mistune==3.2.0 \
-    --hash=sha256:708487c8a8cdd99c9d90eb3ed4c3ed961246ff78ac82f03418f5183ab70e398a \
-    --hash=sha256:febdc629a3c78616b94393c6580551e0e34cc289987ec6c35ed3f4be42d0eee1
+mistune==3.2.1 \
+    --hash=sha256:78cdb0ba5e938053ccf63651b352508d2efa9411dc8810bfb05f2dc5140c0048 \
+    --hash=sha256:7c8e5501d38bac1582e067e46c8343f17d57ea1aaa735823f3aba1fd59c88a28
     # via nbconvert
 mkdocs==1.6.1 \
     --hash=sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2 \

--- a/requirements/dev-lock-windows-ffi-py311.txt
+++ b/requirements/dev-lock-windows-ffi-py311.txt
@@ -1677,9 +1677,9 @@ mergedeep==1.3.4 \
     # via
     #   mkdocs
     #   mkdocs-get-deps
-mistune==3.2.0 \
-    --hash=sha256:708487c8a8cdd99c9d90eb3ed4c3ed961246ff78ac82f03418f5183ab70e398a \
-    --hash=sha256:febdc629a3c78616b94393c6580551e0e34cc289987ec6c35ed3f4be42d0eee1
+mistune==3.2.1 \
+    --hash=sha256:78cdb0ba5e938053ccf63651b352508d2efa9411dc8810bfb05f2dc5140c0048 \
+    --hash=sha256:7c8e5501d38bac1582e067e46c8343f17d57ea1aaa735823f3aba1fd59c88a28
     # via nbconvert
 mkdocs==1.6.1 \
     --hash=sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2 \

--- a/requirements/dev-lock-windows-ffi-py312.txt
+++ b/requirements/dev-lock-windows-ffi-py312.txt
@@ -1671,9 +1671,9 @@ mergedeep==1.3.4 \
     # via
     #   mkdocs
     #   mkdocs-get-deps
-mistune==3.2.0 \
-    --hash=sha256:708487c8a8cdd99c9d90eb3ed4c3ed961246ff78ac82f03418f5183ab70e398a \
-    --hash=sha256:febdc629a3c78616b94393c6580551e0e34cc289987ec6c35ed3f4be42d0eee1
+mistune==3.2.1 \
+    --hash=sha256:78cdb0ba5e938053ccf63651b352508d2efa9411dc8810bfb05f2dc5140c0048 \
+    --hash=sha256:7c8e5501d38bac1582e067e46c8343f17d57ea1aaa735823f3aba1fd59c88a28
     # via nbconvert
 mkdocs==1.6.1 \
     --hash=sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2 \

--- a/requirements/dev-lock.txt
+++ b/requirements/dev-lock.txt
@@ -1722,9 +1722,9 @@ mergedeep==1.3.4 \
     # via
     #   mkdocs
     #   mkdocs-get-deps
-mistune==3.2.0 \
-    --hash=sha256:708487c8a8cdd99c9d90eb3ed4c3ed961246ff78ac82f03418f5183ab70e398a \
-    --hash=sha256:febdc629a3c78616b94393c6580551e0e34cc289987ec6c35ed3f4be42d0eee1
+mistune==3.2.1 \
+    --hash=sha256:78cdb0ba5e938053ccf63651b352508d2efa9411dc8810bfb05f2dc5140c0048 \
+    --hash=sha256:7c8e5501d38bac1582e067e46c8343f17d57ea1aaa735823f3aba1fd59c88a28
     # via nbconvert
 mkdocs==1.6.1 \
     --hash=sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2 \

--- a/spo-kernel/Cargo.lock
+++ b/spo-kernel/Cargo.lock
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "spo-engine"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "criterion",
  "proptest",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "spo-ffi"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "numpy",
  "pyo3",
@@ -848,14 +848,14 @@ dependencies = [
 
 [[package]]
 name = "spo-oscillators"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "spo-types",
 ]
 
 [[package]]
 name = "spo-supervisor"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "serde",
  "serde_json",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "spo-types"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "serde",
  "serde_json",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "spo-wasm"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "js-sys",
  "serde",

--- a/spo-kernel/Cargo.toml
+++ b/spo-kernel/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.5.7"
+version = "0.5.8"
 edition = "2021"
 rust-version = "1.83.0"
 authors = ["Miroslav Sotek <protoscience@anulum.li>"]

--- a/spo-kernel/crates/spo-ffi/pyproject.toml
+++ b/spo-kernel/crates/spo-ffi/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = "maturin"
 
 [project]
 name = "spo-kernel"
-version = "0.5.7"
+version = "0.5.8"
 description = "SCPN Phase Orchestrator — Rust-accelerated UPDE kernel"
 authors = [{name = "Miroslav Sotek", email = "protoscience@anulum.li"}]
 requires-python = ">=3.10"

--- a/src/scpn_phase_orchestrator/server.py
+++ b/src/scpn_phase_orchestrator/server.py
@@ -422,7 +422,7 @@ def create_app(spec_path: str | Path) -> object:  # pragma: no cover
             with sim._lock:
                 sim.event_bus.clear()
 
-    app = FastAPI(title="SPO Dashboard", version="0.5.7", lifespan=_lifespan)
+    app = FastAPI(title="SPO Dashboard", version="0.5.8", lifespan=_lifespan)
 
     @app.middleware("http")
     async def _log_http_request(

--- a/src/scpn_phase_orchestrator/supervisor/policy_rules.py
+++ b/src/scpn_phase_orchestrator/supervisor/policy_rules.py
@@ -362,7 +362,7 @@ def load_policy_stl_specs(path: str | Path) -> list[PolicySTLSpec]:
         raise ValueError(f"cannot read policy rules: {reason}") from None
     try:
         data = yaml.safe_load(raw)
-    except (RecursionError, yaml.YAMLError):
+    except (RecursionError, OverflowError, UnicodeError, yaml.YAMLError):
         raise ValueError("policy rules YAML parse error") from None
     if not isinstance(data, dict) or "stl_monitors" not in data:
         return []
@@ -403,7 +403,7 @@ def load_policy_rules(path: str | Path) -> list[PolicyRule]:
         raise ValueError(f"cannot read policy rules: {reason}") from None
     try:
         data = yaml.safe_load(raw)
-    except (RecursionError, yaml.YAMLError):
+    except (RecursionError, OverflowError, UnicodeError, yaml.YAMLError):
         raise ValueError("policy rules YAML parse error") from None
     if not isinstance(data, dict) or "rules" not in data:
         return []

--- a/src/scpn_phase_orchestrator/supervisor/policy_rules.py
+++ b/src/scpn_phase_orchestrator/supervisor/policy_rules.py
@@ -362,7 +362,7 @@ def load_policy_stl_specs(path: str | Path) -> list[PolicySTLSpec]:
         raise ValueError(f"cannot read policy rules: {reason}") from None
     try:
         data = yaml.safe_load(raw)
-    except (RecursionError, OverflowError, UnicodeError, yaml.YAMLError):
+    except (RecursionError, OverflowError, UnicodeError, ValueError, yaml.YAMLError):
         raise ValueError("policy rules YAML parse error") from None
     if not isinstance(data, dict) or "stl_monitors" not in data:
         return []
@@ -403,7 +403,7 @@ def load_policy_rules(path: str | Path) -> list[PolicyRule]:
         raise ValueError(f"cannot read policy rules: {reason}") from None
     try:
         data = yaml.safe_load(raw)
-    except (RecursionError, OverflowError, UnicodeError, yaml.YAMLError):
+    except (RecursionError, OverflowError, UnicodeError, ValueError, yaml.YAMLError):
         raise ValueError("policy rules YAML parse error") from None
     if not isinstance(data, dict) or "rules" not in data:
         return []

--- a/tests/test_policy_rules.py
+++ b/tests/test_policy_rules.py
@@ -216,6 +216,24 @@ def test_load_policy_rules_recursion_error_is_parse_error(tmp_path, monkeypatch)
         load_policy_rules(p)
 
 
+def test_load_policy_rules_fuzzer_unicode_overflow_is_parse_error(tmp_path):
+    """Malformed YAML Unicode escapes from fuzzing must not escape the loader."""
+    p = tmp_path / "policy.yaml"
+    p.write_text('"\\\\\\U' + ("e" * 57) + "\\\\~", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="policy rules YAML parse error"):
+        load_policy_rules(p)
+
+
+def test_load_policy_stl_specs_fuzzer_unicode_overflow_is_parse_error(tmp_path):
+    """The STL policy loader shares the same YAML parser hardening contract."""
+    p = tmp_path / "policy.yaml"
+    p.write_text('"\\\\\\U' + ("e" * 57) + "\\\\~", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="policy rules YAML parse error"):
+        load_policy_stl_specs(p)
+
+
 def test_out_of_range_layer_returns_none():
     rule = _rule(metric="R", layer=99, op=">", threshold=0.0)
     engine = PolicyEngine([rule])

--- a/tests/test_tools_check_github_action_refs.py
+++ b/tests/test_tools_check_github_action_refs.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Commercial license available
+# (c) Concepts 1996-2026 Miroslav Sotek. All rights reserved.
+# (c) Code 2020-2026 Miroslav Sotek. All rights reserved.
+# ORCID: 0009-0009-3560-0851
+# Contact: www.anulum.li | protoscience@anulum.li
+# SCPN Phase Orchestrator - Tests for check_github_action_refs.py
+
+"""Unit tests for the GitHub Actions reference guard."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+TOOLS_DIR = Path(__file__).resolve().parents[1] / "tools"
+SCRIPT = TOOLS_DIR / "check_github_action_refs.py"
+
+
+def _load() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "_check_github_action_refs_test_mod", SCRIPT
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+mod = _load()
+
+
+def test_extract_action_refs_ignores_local_and_docker_refs(tmp_path: Path) -> None:
+    workflow = tmp_path / "workflow.yml"
+    workflow.write_text(
+        """
+        steps:
+          - uses: actions/checkout@0123456789012345678901234567890123456789
+          - uses: ./local-action
+          - uses: docker://alpine:3.20
+        """,
+        encoding="utf-8",
+    )
+
+    refs = mod.extract_action_refs([workflow])
+
+    assert len(refs) == 1
+    assert refs[0].repo == "actions/checkout"
+    assert refs[0].ref == "0123456789012345678901234567890123456789"
+
+
+def test_validate_refs_reports_missing_ref(monkeypatch) -> None:
+    action_ref = mod.ActionRef(
+        path=Path(".github/workflows/publish.yml"),
+        line=10,
+        repo="PyO3/maturin-action",
+        ref="a" * 40,
+    )
+
+    def fake_gh_api(path: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(["gh", "api", path], 1, "", "missing")
+
+    monkeypatch.setattr(mod, "_gh_api", fake_gh_api)
+
+    missing, non_sha = mod.validate_refs([action_ref])
+
+    assert missing == [action_ref]
+    assert non_sha == []
+
+
+def test_validate_refs_reports_non_sha_ref(monkeypatch) -> None:
+    action_ref = mod.ActionRef(
+        path=Path(".github/workflows/publish.yml"),
+        line=10,
+        repo="actions/checkout",
+        ref="v6",
+    )
+
+    def fake_gh_api(path: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(["gh", "api", path], 0, "{}", "")
+
+    monkeypatch.setattr(mod, "_gh_api", fake_gh_api)
+
+    missing, non_sha = mod.validate_refs([action_ref])
+
+    assert missing == []
+    assert non_sha == [action_ref]
+
+
+def test_main_returns_zero_for_resolving_sha(tmp_path: Path, monkeypatch) -> None:
+    workflow = tmp_path / "workflow.yml"
+    workflow.write_text(
+        "- uses: actions/checkout@0123456789012345678901234567890123456789\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(mod.shutil, "which", lambda _: "/usr/bin/gh")
+    monkeypatch.setattr(
+        mod,
+        "_gh_api",
+        lambda path: subprocess.CompletedProcess(["gh", "api", path], 0, "{}", ""),
+    )
+
+    assert mod.main([str(workflow)]) == 0
+
+
+def test_main_returns_one_when_gh_missing(tmp_path: Path, monkeypatch) -> None:
+    workflow = tmp_path / "workflow.yml"
+    workflow.write_text(
+        "- uses: actions/checkout@0123456789012345678901234567890123456789\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(mod.shutil, "which", lambda _: None)
+
+    assert mod.main([str(workflow)]) == 1

--- a/tools/check_github_action_refs.py
+++ b/tools/check_github_action_refs.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Commercial license available
+# (c) Concepts 1996-2026 Miroslav Sotek. All rights reserved.
+# (c) Code 2020-2026 Miroslav Sotek. All rights reserved.
+# ORCID: 0009-0009-3560-0851
+# Contact: www.anulum.li | protoscience@anulum.li
+# SCPN Phase Orchestrator - GitHub Action reference guard
+
+"""Validate that pinned GitHub Action references in workflow files resolve.
+
+The publish workflow pins actions by commit SHA for supply-chain stability.
+GitHub Actions fails during job setup when a pin is not an actual commit or
+tag ref in the referenced repository. This guard catches those failures in the
+preflight job before expensive release jobs fan out.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import sys
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+USES_RE = re.compile(r"^\s*-\s*uses:\s*([^\s#]+)", re.MULTILINE)
+FULL_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+@dataclass(frozen=True)
+class ActionRef:
+    """A remote GitHub Action reference extracted from a workflow."""
+
+    path: Path
+    line: int
+    repo: str
+    ref: str
+
+
+def _line_number(text: str, offset: int) -> int:
+    return text.count("\n", 0, offset) + 1
+
+
+def _is_remote_github_action(spec: str) -> bool:
+    """Return true for owner/repo actions, not local or docker actions."""
+    if spec.startswith("./") or spec.startswith("docker://"):
+        return False
+    if "@" not in spec:
+        return False
+    repo, _ = spec.rsplit("@", 1)
+    return repo.count("/") == 1
+
+
+def extract_action_refs(paths: Iterable[Path]) -> list[ActionRef]:
+    """Extract remote ``owner/repo@ref`` action refs from workflow files."""
+    refs: list[ActionRef] = []
+    for path in paths:
+        text = path.read_text(encoding="utf-8")
+        for match in USES_RE.finditer(text):
+            spec = match.group(1)
+            if not _is_remote_github_action(spec):
+                continue
+            repo, ref = spec.rsplit("@", 1)
+            refs.append(
+                ActionRef(
+                    path=path,
+                    line=_line_number(text, match.start()),
+                    repo=repo,
+                    ref=ref,
+                )
+            )
+    return refs
+
+
+def _gh_api(path: str) -> subprocess.CompletedProcess[str]:
+    gh_bin = shutil.which("gh")
+    if gh_bin is None:
+        return subprocess.CompletedProcess(["gh", "api", path], 127, "", "gh missing")
+    return subprocess.run(
+        [gh_bin, "api", path],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def ref_resolves(repo: str, ref: str) -> bool:
+    """Return true when ``ref`` resolves as a commit or tag in ``repo``."""
+    commit = _gh_api(f"repos/{repo}/commits/{ref}")
+    if commit.returncode == 0:
+        return True
+
+    tag = _gh_api(f"repos/{repo}/git/ref/tags/{ref}")
+    return tag.returncode == 0
+
+
+def validate_refs(refs: Sequence[ActionRef]) -> tuple[list[ActionRef], list[ActionRef]]:
+    """Split refs into missing refs and non-SHA refs."""
+    missing: list[ActionRef] = []
+    non_sha: list[ActionRef] = []
+
+    for action_ref in refs:
+        if not FULL_SHA_RE.fullmatch(action_ref.ref):
+            non_sha.append(action_ref)
+        if not ref_resolves(action_ref.repo, action_ref.ref):
+            missing.append(action_ref)
+
+    return missing, non_sha
+
+
+def _format_ref(action_ref: ActionRef) -> str:
+    rel = (
+        action_ref.path.relative_to(ROOT)
+        if action_ref.path.is_relative_to(ROOT)
+        else action_ref.path
+    )
+    return f"{rel}:{action_ref.line}: {action_ref.repo}@{action_ref.ref}"
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    paths = (
+        [ROOT / ".github/workflows/publish.yml"]
+        if not args
+        else [Path(a) for a in args]
+    )
+
+    if shutil.which("gh") is None:
+        print("ERROR: GitHub CLI `gh` is required to validate action refs")
+        return 1
+
+    refs = extract_action_refs(paths)
+    missing, non_sha = validate_refs(refs)
+
+    if non_sha:
+        print("ERROR: action refs must be pinned to full 40-character commit SHAs")
+        for action_ref in non_sha:
+            print(f"  {_format_ref(action_ref)}")
+        return 1
+
+    if missing:
+        print("ERROR: action refs do not resolve in GitHub")
+        for action_ref in missing:
+            print(f"  {_format_ref(action_ref)}")
+        return 1
+
+    print(f"OK: {len(refs)} GitHub Action refs resolve")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- replace invalid pinned release-workflow action refs with resolvable commit pins
- add a GitHub Action reference guard to publish preflight
- bump release metadata to 0.5.8 after deleting failed v0.5.7
- document release hygiene and tag retry policy

## Validation
- python tools/check_github_action_refs.py .github/workflows/publish.yml
- python tools/check_version_sync.py
- GITHUB_REF_NAME=v0.5.8 python tools/check_release_tag_version.py
- pytest release-tool guard tests
- corrected publish preflight pytest scope: 5955 passed, 10 skipped, 3 xpassed
- local sdist/wheel build and twine check
- PYTHONPATH=src mkdocs build --strict
- pre-push 11 gates

Co-Authored-By: Arcane Sapience <protoscience@anulum.li>