### PR TITLE
Fix release deployment for 0.5.9

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,14 +67,19 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64
+            python_interpreter: /opt/python/cp312-cp312/bin/python
           - os: ubuntu-latest
             target: aarch64
+            python_interpreter: /opt/python/cp312-cp312/bin/python
           - os: macos-latest
             target: x86_64
+            python_interpreter: python
           - os: macos-latest
             target: aarch64
+            python_interpreter: python
           - os: windows-latest
             target: x86_64
+            python_interpreter: python
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -87,7 +92,7 @@ jobs:
         with:
           target: ${{ matrix.target }}
           manylinux: auto
-          args: --release -m spo-kernel/crates/spo-ffi/Cargo.toml --out dist
+          args: --release -m spo-kernel/crates/spo-ffi/Cargo.toml --out dist -i ${{ matrix.python_interpreter }}
       - name: Upload wheel
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.9] - 2026-05-06
+
+### Fixed
+
+- Forced Linux manylinux Rust wheel builds to use the explicit CPython 3.12
+  interpreter path provided by the PyPA manylinux images, avoiding maturin's
+  ambiguous default `python3` discovery path.
+- Refreshed stale pinned Docker base-image digests for the release container
+  build after the previous Rust image digest stopped resolving from Docker Hub,
+  then aligned the FFI builder with the runtime CPython 3.12 image while
+  installing the stable Rust 1.95 toolchain inside that builder.
+
+### Added
+
+- Added release-workflow regression tests for Linux maturin interpreter
+  selection and container base-image digest pins.
+
 ## [0.5.8] - 2026-05-06
 
 ### Fixed
@@ -1450,7 +1467,8 @@ proxy to the full arXiv:2603.15031 Transformer architecture:
 - Module linkage guard (`tools/check_test_module_linkage.py`) requiring test files for all source modules
 - Rust kernel (`spo-kernel/`) with PyO3 bindings for UPDEEngine, RegimeManager, CoherenceMonitor
 
-[Unreleased]: https://github.com/anulum/scpn-phase-orchestrator/compare/v0.5.8...HEAD
+[Unreleased]: https://github.com/anulum/scpn-phase-orchestrator/compare/v0.5.9...HEAD
+[0.5.9]: https://github.com/anulum/scpn-phase-orchestrator/compare/v0.5.8...v0.5.9
 [0.5.8]: https://github.com/anulum/scpn-phase-orchestrator/compare/v0.5.0...v0.5.8
 [0.5.0]: https://github.com/anulum/scpn-phase-orchestrator/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/anulum/scpn-phase-orchestrator/compare/v0.4.0...v0.4.1

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,7 +7,7 @@ authors:
     given-names: Miroslav
     orcid: "https://orcid.org/0009-0009-3560-0851"
     email: protoscience@anulum.li
-version: 0.5.8
+version: 0.5.9
 date-released: "2026-05-06"
 license: AGPL-3.0-or-later
 url: "https://github.com/anulum/scpn-phase-orchestrator"

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,15 +6,23 @@
 # SCPN Phase Orchestrator — Multi-stage Container Image
 
 # ── Stage 1: Build Rust FFI extension ────────────────────────────
-# Pin base images by digest for reproducible builds
-FROM rust:1.83-slim@sha256:89e45d1b4de96d61e457618ae4da44690eae5578fe2f11d26d1ed02ce5c8e412 AS rust-builder
+# Pin base images by digest for reproducible builds. Build the FFI wheel with
+# the same CPython minor as the runtime image so the extracted extension imports.
+FROM python:3.12-slim@sha256:46cb7cc2877e60fbd5e21a9ae6115c30ace7a077b9f8772da879e4590c18c2e3 AS rust-builder
+
+ENV CARGO_HOME=/usr/local/cargo \
+    RUSTUP_HOME=/usr/local/rustup \
+    PATH=/usr/local/cargo/bin:$PATH
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    python3-dev python3-pip python3-venv && \
+    build-essential ca-certificates curl && \
     rm -rf /var/lib/apt/lists/*
 
+RUN curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs | \
+    sh -s -- -y --profile minimal --default-toolchain 1.95.0
+
 COPY requirements/ci-tools.txt /tmp/ci-tools.txt
-RUN pip3 install --break-system-packages --no-cache-dir \
+RUN python -m pip install --no-cache-dir \
     --require-hashes --no-deps -r /tmp/ci-tools.txt
 
 WORKDIR /build
@@ -24,7 +32,7 @@ RUN cd spo-kernel && \
     maturin build --release -m crates/spo-ffi/Cargo.toml --out /wheels
 
 # ── Stage 2: Build Python package ────────────────────────────────
-FROM python:3.12-slim@sha256:2be8daddbd3438e0e0c82ddd4a37e0e7ff3c1e0a0e7e0e4ed4e3be0ba26d3e21 AS python-builder
+FROM python:3.12-slim@sha256:46cb7cc2877e60fbd5e21a9ae6115c30ace7a077b9f8772da879e4590c18c2e3 AS python-builder
 
 WORKDIR /build
 
@@ -36,7 +44,7 @@ RUN python -m pip install --no-cache-dir --prefix=/install \
     python -c "import glob, pathlib, sysconfig, zipfile; target = pathlib.Path(sysconfig.get_paths(vars={'base': '/install', 'platbase': '/install'})['platlib']); target.mkdir(parents=True, exist_ok=True); wheels = glob.glob('/wheels/*.whl'); assert len(wheels) == 1, wheels; zipfile.ZipFile(wheels[0]).extractall(target)"
 
 # ── Stage 3: Production image ────────────────────────────────────
-FROM python:3.12-slim@sha256:2be8daddbd3438e0e0c82ddd4a37e0e7ff3c1e0a0e7e0e4ed4e3be0ba26d3e21 AS production
+FROM python:3.12-slim@sha256:46cb7cc2877e60fbd5e21a9ae6115c30ace7a077b9f8772da879e4590c18c2e3 AS production
 
 LABEL maintainer="Miroslav Sotek <protoscience@anulum.li>"
 LABEL org.opencontainers.image.source="https://github.com/anulum/scpn-phase-orchestrator"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Domain-agnostic coherence control compiler built on Kuramoto/UPDE phase dynamics
 
 > **Active Development** — SCPN Phase Orchestrator is under intensive development. The core UPDE engine, all 12 integration methods, 3-channel oscillator extraction (P/I/S), supervisor with regime management, and Rust FFI acceleration are fully functional and tested (3 945 Python tests passed, 567 Rust tests, zero functional failures). Rust FFI coverage now spans 53 engine modules across UPDE, coupling, monitor, SSGF, and autotune subsystems with a reference documentation page for every Rust-accelerated module. APIs may evolve as this work progresses.
 
-**Version:** 0.5.8
+**Version:** 0.5.9
 **Status:** 142 Python Modules | 12 Engine Variants | 19 Monitors | 36 Domainpacks | 53 Rust Engine Modules | 567 Rust Tests | 3 945 Python Tests Passed
 
 [![CI](https://github.com/anulum/scpn-phase-orchestrator/actions/workflows/ci.yml/badge.svg)](https://github.com/anulum/scpn-phase-orchestrator/actions/workflows/ci.yml)

--- a/docs/RELEASE_HYGIENE.md
+++ b/docs/RELEASE_HYGIENE.md
@@ -20,6 +20,22 @@ If a tag-triggered publish run fails before uploading, delete the failed tag,
 bump the release metadata, fix the workflow on a pull request, and tag the new
 version only after CI and the local release guards pass.
 
+If PyPI upload succeeds but a later release job fails, do not reuse the same
+version. PyPI files are immutable, so the repair must land on `main` with a new
+patch version and a new tag.
+
+For Rust wheel builds in `publish.yml`, Linux manylinux jobs must pass an
+explicit CPython interpreter path such as
+`/opt/python/cp312-cp312/bin/python` to maturin. The manylinux container PATH
+does not guarantee a usable `python3` selector for every target.
+
+For the container job, refresh pinned base-image digests before tagging. A stale
+`tag@sha256` pair fails before security scanning because Docker cannot resolve
+the source metadata. The container FFI builder should use the same CPython minor
+as the runtime image and install the stable Rust toolchain used by CI, not the
+workspace MSRV, because locked transitive crates may require newer Cargo
+manifest support and a mismatched CPython wheel will not import at runtime.
+
 ## Fuzzing Findings
 
 ClusterFuzzLite failures are treated as release blockers when the crash is

--- a/docs/VALIDATION_REPORT.md
+++ b/docs/VALIDATION_REPORT.md
@@ -8,7 +8,7 @@ Contact: www.anulum.li | protoscience@anulum.li
 
 # Software Verification & Validation Report
 
-**Version:** 0.5.8
+**Version:** 0.5.9
 **Date:** 2026-03-28
 **Author:** Miroslav Šotek / Arcane Sapience
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scpn-phase-orchestrator"
-version = "0.5.8"
+version = "0.5.9"
 description = "Domain-agnostic coherence control compiler built on SCPN's Kuramoto/UPDE framework"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/spo-kernel/Cargo.lock
+++ b/spo-kernel/Cargo.lock
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "spo-engine"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "criterion",
  "proptest",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "spo-ffi"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "numpy",
  "pyo3",
@@ -848,14 +848,14 @@ dependencies = [
 
 [[package]]
 name = "spo-oscillators"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "spo-types",
 ]
 
 [[package]]
 name = "spo-supervisor"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "serde",
  "serde_json",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "spo-types"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "serde",
  "serde_json",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "spo-wasm"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "js-sys",
  "serde",

--- a/spo-kernel/Cargo.toml
+++ b/spo-kernel/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.5.8"
+version = "0.5.9"
 edition = "2021"
 rust-version = "1.83.0"
 authors = ["Miroslav Sotek <protoscience@anulum.li>"]

--- a/spo-kernel/crates/spo-ffi/pyproject.toml
+++ b/spo-kernel/crates/spo-ffi/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = "maturin"
 
 [project]
 name = "spo-kernel"
-version = "0.5.8"
+version = "0.5.9"
 description = "SCPN Phase Orchestrator — Rust-accelerated UPDE kernel"
 authors = [{name = "Miroslav Sotek", email = "protoscience@anulum.li"}]
 requires-python = ">=3.10"

--- a/src/scpn_phase_orchestrator/server.py
+++ b/src/scpn_phase_orchestrator/server.py
@@ -422,7 +422,7 @@ def create_app(spec_path: str | Path) -> object:  # pragma: no cover
             with sim._lock:
                 sim.event_bus.clear()
 
-    app = FastAPI(title="SPO Dashboard", version="0.5.8", lifespan=_lifespan)
+    app = FastAPI(title="SPO Dashboard", version="0.5.9", lifespan=_lifespan)
 
     @app.middleware("http")
     async def _log_http_request(

--- a/tests/test_publish_workflow_hygiene.py
+++ b/tests/test_publish_workflow_hygiene.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Commercial license available
+# (c) Concepts 1996-2026 Miroslav Sotek. All rights reserved.
+# (c) Code 2020-2026 Miroslav Sotek. All rights reserved.
+# ORCID: 0009-0009-3560-0851
+# Contact: www.anulum.li | protoscience@anulum.li
+# SCPN Phase Orchestrator - Publish workflow hygiene tests
+
+"""Regression tests for release workflow and container deployment hygiene."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _publish_workflow() -> dict[str, object]:
+    return yaml.safe_load((ROOT / ".github/workflows/publish.yml").read_text())
+
+
+def test_linux_maturin_wheels_use_manylinux_python312_interpreter() -> None:
+    workflow = _publish_workflow()
+    build_wheels = workflow["jobs"]["build-wheels"]  # type: ignore[index]
+    matrix = build_wheels["strategy"]["matrix"]["include"]  # type: ignore[index]
+
+    linux_rows = [row for row in matrix if row["os"] == "ubuntu-latest"]
+    assert linux_rows
+    assert all(
+        row["python_interpreter"] == "/opt/python/cp312-cp312/bin/python"
+        for row in linux_rows
+    )
+
+
+def test_maturin_step_uses_matrix_interpreter() -> None:
+    workflow = _publish_workflow()
+    steps = workflow["jobs"]["build-wheels"]["steps"]  # type: ignore[index]
+    maturin_step = next(
+        step for step in steps if step.get("name") == "Build wheel via maturin"
+    )
+
+    args = maturin_step["with"]["args"]
+    assert "-i ${{ matrix.python_interpreter }}" in args
+
+
+def test_dockerfile_base_digests_match_known_resolving_manifests() -> None:
+    dockerfile = (ROOT / "Dockerfile").read_text()
+
+    assert (
+        "python:3.12-slim@sha256:"
+        "46cb7cc2877e60fbd5e21a9ae6115c30ace7a077b9f8772da879e4590c18c2e3"
+    ) in dockerfile
+    assert dockerfile.count("python:3.12-slim@sha256:") == 3
+
+    assert (
+        "sha256:89e45d1b4de96d61e457618ae4da44690eae5578fe2f11d26d1ed02ce5c8e412"
+        not in dockerfile
+    )
+    assert "rust:1.83-slim" not in dockerfile
+    assert "rust:1.95-slim" not in dockerfile
+    assert (
+        "sha256:2be8daddbd3438e0e0c82ddd4a37e0e7ff3c1e0a0e7e0e4ed4e3be0ba26d3e21"
+        not in dockerfile
+    )


### PR DESCRIPTION
## Summary
- repair Linux manylinux maturin wheel builds with explicit CPython interpreter selection
- repair the release container build by using a pinned Python 3.12 builder/runtime base and installing Rust 1.95 inside the FFI builder
- bump release metadata to 0.5.9 because 0.5.8 artifacts were uploaded to PyPI and cannot be reused
- add release workflow/container hygiene tests and documentation

## Validation
- local pre-push gate passed twice: ndarray hygiene, Ruff, version sync, mypy, module linkage, pytest, Bandit, cargo fmt, cargo clippy, cargo test
- focused release hygiene tests passed
- full Docker image build passed
- Docker import smoke passed for scpn_phase_orchestrator and spo_kernel

Co-Authored-By: Arcane Sapience <protoscience@anulum.li>