### PR TITLE
ci: isolate slow stability tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,7 @@ jobs:
           --ignore=tests/test_quantum_bridge_live.py
           --ignore=tests/test_geometry_walk.py
           --ignore-glob=tests/test_nn_physics_validation*.py
+          -m "not slow"
           ${{ matrix.python-version == '3.12' && '--cov=scpn_phase_orchestrator --cov-report=term-missing --cov-fail-under=0' || '' }}
       - name: Rename coverage data (test)
         if: matrix.python-version == '3.12'
@@ -97,6 +98,33 @@ jobs:
         run: |
           pip install --require-hashes --no-deps -r requirements/dev-lock.txt && pip install --no-deps -e .
           jupyter nbconvert --execute --to notebook notebooks/*.ipynb --ExecutePreprocessor.timeout=120
+
+  slow-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      HYPOTHESIS_PROFILE: ci
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.12"
+          cache: pip
+      - run: pip install --require-hashes --no-deps -r requirements/dev-lock.txt && pip install --no-deps -e .
+      - name: Run slow stability tests once
+        run: >
+          pytest tests/ -v --tb=short
+          --ignore=tests/test_kuramoto_layer.py
+          --ignore=tests/test_stuart_landau_nn.py
+          --ignore=tests/test_bold.py
+          --ignore=tests/test_reservoir.py
+          --ignore=tests/test_ude_kuramoto.py
+          --ignore=tests/test_inverse.py
+          --ignore=tests/test_oim.py
+          --ignore=tests/test_quantum_bridge_live.py
+          --ignore=tests/test_geometry_walk.py
+          --ignore-glob=tests/test_nn_physics_validation*.py
+          -m slow
 
   coverage-guard:
     needs: [test, ffi-test]
@@ -242,6 +270,7 @@ jobs:
             --ignore=tests/test_quantum_bridge_live.py \
             --ignore=tests/test_geometry_walk.py \
             --ignore-glob=tests/test_nn_physics_validation*.py \
+            -m "not slow" \
             --cov=scpn_phase_orchestrator --cov-report= --cov-fail-under=0
           mv .coverage .coverage.ffi
       - name: Upload coverage data (ffi, ubuntu only)
@@ -269,7 +298,8 @@ jobs:
             --ignore=tests/test_oim.py \
             --ignore=tests/test_quantum_bridge_live.py \
             --ignore=tests/test_geometry_walk.py \
-            --ignore-glob=tests/test_nn_physics_validation*.py
+            --ignore-glob=tests/test_nn_physics_validation*.py \
+            -m "not slow"
       - name: Build and test (Windows)
         if: runner.os == 'Windows'
         shell: bash
@@ -289,7 +319,8 @@ jobs:
             --ignore=tests/test_oim.py \
             --ignore=tests/test_quantum_bridge_live.py \
             --ignore=tests/test_geometry_walk.py \
-            --ignore-glob=tests/test_nn_physics_validation*.py
+            --ignore-glob=tests/test_nn_physics_validation*.py \
+            -m "not slow"
 
   cargo-audit:
     runs-on: ubuntu-latest
@@ -340,7 +371,7 @@ jobs:
           path: bench/current.json
 
   ci-gate:
-    needs: [lint, typecheck, test, security, rust-check, cargo-audit, rust-msrv, coverage-guard, module-linkage, ffi-test, benchmark]
+    needs: [lint, typecheck, test, slow-tests, security, rust-check, cargo-audit, rust-msrv, coverage-guard, module-linkage, ffi-test, benchmark]
     runs-on: ubuntu-latest
     steps:
       - run: echo "All checks passed"

--- a/tests/test_publish_workflow_hygiene.py
+++ b/tests/test_publish_workflow_hygiene.py
@@ -25,6 +25,13 @@ def _publish_workflow() -> dict[str, Any]:
     )
 
 
+def _ci_workflow() -> dict[str, Any]:
+    return cast(
+        "dict[str, Any]",
+        yaml.safe_load((ROOT / ".github/workflows/ci.yml").read_text()),
+    )
+
+
 def test_linux_maturin_wheels_use_executable_python312_interpreter() -> None:
     workflow = _publish_workflow()
     matrix = workflow["jobs"]["build-wheels"]["strategy"]["matrix"]["include"]
@@ -98,3 +105,37 @@ def test_container_scans_gate_only_fixable_high_findings() -> None:
     grype_command = grype_step["run"]
     assert "--fail-on high" in grype_command
     assert "--only-fixed" in grype_command
+
+
+def test_ci_slow_tests_run_once_outside_python_matrix() -> None:
+    workflow = _ci_workflow()
+    jobs = workflow["jobs"]
+
+    test_command = next(
+        step["run"]
+        for step in jobs["test"]["steps"]
+        if step.get("name") == "Run tests (with coverage on 3.12)"
+    )
+    assert '-m "not slow"' in test_command
+
+    slow_job = jobs["slow-tests"]
+    assert slow_job["timeout-minutes"] == 20
+    assert slow_job["steps"][1]["with"]["python-version"] == "3.12"
+    slow_command = slow_job["steps"][-1]["run"]
+    assert "-m slow" in slow_command
+
+    gate_needs = jobs["ci-gate"]["needs"]
+    assert "slow-tests" in gate_needs
+
+
+def test_ffi_matrix_excludes_slow_tests() -> None:
+    workflow = _ci_workflow()
+    ffi_steps = workflow["jobs"]["ffi-test"]["steps"]
+    pytest_commands = [
+        str(step["run"])
+        for step in ffi_steps
+        if "pytest tests/" in str(step.get("run"))
+    ]
+
+    assert pytest_commands
+    assert all('-m "not slow"' in command for command in pytest_commands)


### PR DESCRIPTION
## Summary
- keep regular Python and FFI CI matrix lanes on non-slow tests
- add a bounded Python 3.12 slow-tests job for slow stability coverage
- require slow-tests through ci-gate

## Root cause
The v0.5.10 deployment succeeded, but the post-merge main CI run had the Python 3.11 test job wedged past its configured timeout. Local reproduction showed the AttnRes slow stability path is disproportionately slow on Python 3.11, while the same slow stability suite passes quickly on Python 3.12. The previous workflow marker contract already labelled these tests as slow, but CI ran them in every matrix lane.

## Validation
- ./.venv-linux/bin/python -m pytest tests/test_publish_workflow_hygiene.py -q
- ./.venv-linux/bin/ruff check tests/test_publish_workflow_hygiene.py
- ./.venv-linux/bin/ruff format --check tests/test_publish_workflow_hygiene.py
- ./.venv-linux/bin/python tools/check_github_action_refs.py .github/workflows/ci.yml .github/workflows/publish.yml
- HYPOTHESIS_PROFILE=ci ./.venv-linux/bin/python -m pytest tests/test_attention_residuals_stability.py -m slow -q --tb=short --durations=5
- git pre-push hook: all 11 gates passed

Co-Authored-By: Arcane Sapience <protoscience@anulum.li>